### PR TITLE
Release 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ This plugin provides a `bzm - HTTP Sampler` (multi-protocol: **HTTP/1.1**, **HTT
 - [**HTTP Async Controller**](#readme-http-async-controller)
   - [Controller panel](#readme-http-async-panel)
 - [**JMeter property reference**](#readme-jmeter-property-reference)
+- [**Logging and low-level debugging**](#readme-logging)
+  - [Keeping Jetty's own logging out of it](#readme-logging-jetty-verbosity)
 - [**Building from source**](#readme-building-from-source)
 - [**License**](#readme-license)
 
@@ -383,11 +385,16 @@ In **View Results Tree**, rows may follow **completion order**, not test-plan or
 > [!NOTE]
 > Anything else you add as a **direct child**—timers, a different sampler type, an assertion, another controller, etc.—still runs **in tree order**. Before that element runs, the controller **waits until every BlazeMeter HTTP request started above it has completed**. Use that pattern when you mean “kick off these BlazeMeter HTTP calls together, then run the following steps only after they are all done.”
 
+> [!NOTE]
+> **When a Thread Group runs for a duration**, the requests this controller had already sent when the time ran out are still collected and reported, the same way JMeter lets a running request finish before it stops a thread. Nothing new is dispatched once the time is up, so no load reaches the system under test past the end of the run; the thread ends as soon as the responses it was already waiting for arrive. Tune or disable that grace with **`blazemeter.http.schedulerHoldMillis`**. A **Stop** is immediate and is never held off.
+
 
 <a id="readme-jmeter-property-reference"></a>
 # JMeter property reference
 
 Restart JMeter after changing JMeter properties that are applied when affected classes initialize.
+
+The diagnostic switches are **not** in this table: `blazemeter.http.lowLevelLog` is read as a JVM system property, not as a JMeter property — see **[Logging and low-level debugging](#readme-logging)**.
 
 | **Attribute** | **Description** | **Default** |
 |---|---|---:|
@@ -406,6 +413,7 @@ Restart JMeter after changing JMeter properties that are applied when affected c
 | **blazemeter.http.maxConcurrentPushedStreams** | Maximum number of server push streams concurrently received | 100 |
 | **blazemeter.http.maxRequestsPerConnection** | Maximum Jetty HTTP requests per pooled connection | 100 |
 | **blazemeter.http.maxConcurrentAsyncInController** | Default concurrency cap inside **`bzm - HTTP Async Controller`** when parallel limiting is unchecked | 100 |
+| **blazemeter.http.schedulerHoldMillis** | How far **`bzm - HTTP Async Controller`** may push a thread's scheduled end while its requests are still on the wire, so a duration-limited run collects the responses it already asked for instead of dropping them. Renewed while requests are pending and given back as soon as they are collected; a Stop is never held off. Set to **0** to let the schedule cut mid-flight | 2000 |
 | **HTTPSampler.response_timeout** | Default response timeout (ms) when the sampler defines none | 0 |
 | **http.post_add_content_type_if_missing** | Add Content-Type header if missing? | false |
 | **blazemeter.http.enableHttp3** | Enable HTTP/3 support (Alt-Svc + QUIC) | profile |
@@ -433,6 +441,50 @@ Restart JMeter after changing JMeter properties that are applied when affected c
 | **blazemeter.http.controller.generateParentSample** | If you group all requests into a parent sample | false |
 | **blazemeter.http.controller.limitMaxParallel** | Limit max number of parallel executions | false |
 | **blazemeter.http.controller.maxConcurrentAsyncInController** | Maximum parallel requests (integer ≥ 1) | 100 |
+
+
+<a id="readme-logging"></a>
+# Logging and low-level debugging
+
+The plugin logs through JMeter's own logging, so its lines land in **`jmeter.log`** next to JMeter's, under logger names like **`c.b.j.h.c.HTTP2Controller`** and **`c.b.j.h.c.HTTP2JettyClient`**. Warnings and errors are on by default. Everything below is for diagnosing a run and should be **off during a load test**: with both switches on, a single-thread nine-second run with two requests per iteration wrote about **2900 lines**, and that scales with threads and requests.
+
+Two switches, and they do different things:
+
+| **Switch** | **What it does** |
+|---|---|
+| **`-Dblazemeter.http.lowLevelLog=true`** | Opens the plugin's internal traces: every dispatch and completion in the async controller, the request/response steps in the client, protocol negotiation and fallback decisions, plus HTTP/2 frame logging. A **JVM system property** — see the note below |
+| **`-Lcom.blazemeter=DEBUG`** | Raises the log level so DEBUG lines are written at all. Without it the switch above produces nothing |
+
+> [!IMPORTANT]
+> **`-Dblazemeter.http.lowLevelLog=true`**, not `-J`. This one is read as a JVM system property, so JMeter's `-J` (test-plan properties) does **not** set it. In the GUI, or in any launcher script, pass it through **`JVM_ARGS`** instead: `set JVM_ARGS=-Dblazemeter.http.lowLevelLog=true` on Windows, `export JVM_ARGS="-Dblazemeter.http.lowLevelLog=true"` on Linux/macOS.
+
+<a id="readme-logging-jetty-verbosity"></a>
+### Keeping Jetty's own logging out of it
+
+The packaged JAR relocates its Jetty into **`com.blazemeter.jmeter.http2.shaded.org.eclipse.jetty`**, which sits *under* `com.blazemeter`. So **`-Lcom.blazemeter=DEBUG` also turns on all of Jetty's internal logging** — selectors, connection pools, buffer pools, TLS — and that is not something the plugin's own switch has any say over. On a two-iteration plan with two requests each, that is **2659 Jetty lines against 261 from the plugin**.
+
+Silence that package and the log becomes readable:
+
+```bash
+java -Dblazemeter.http.lowLevelLog=true -jar $JMETER_HOME/bin/ApacheJMeter.jar \
+  -n -t plan.jmx -l results.jtl -j run.log \
+  -Lcom.blazemeter=DEBUG -Lcom.blazemeter.jmeter.http2.shaded=INFO
+```
+
+For a permanent setting, or for the GUI, put the same two levels in **`$JMETER_HOME/bin/log4j2.xml`**:
+
+```xml
+<Loggers>
+  <Logger name="com.blazemeter" level="debug"/>
+  <!-- The plugin's relocated Jetty: leave it at info or the plugin's own lines are buried. -->
+  <Logger name="com.blazemeter.jmeter.http2.shaded" level="info"/>
+</Loggers>
+```
+
+Turn Jetty's own logging **on** only when the question is about the transport itself (a stalled connection, a TLS handshake, HTTP/2 frames) — by dropping that second logger, or by raising just one package, e.g. `-Lcom.blazemeter.jmeter.http2.shaded.org.eclipse.jetty.io=DEBUG`.
+
+> [!NOTE]
+> With the low-level switch on, the client also appends HTTP/2 frame traces to an **`http2-debug.log`** file, resolved relative to the working directory JMeter was started from (`<cwd>/jmeter-http2-plugin/target/http2-debug.log`). It is created only while that switch is on.
 
 
 <a id="readme-building-from-source"></a>

--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Add it with **Add → Logic Controller → bzm - HTTP Async Controller**. **`bzm
 | **Field** | **Description** | **Default** |
 |---|---|---|
 | Generate Parent Sample | Wraps child BlazeMeter HTTP results in one parent sample (sub-results in listeners/reports). | Off (`false`) |
+| Include duration of timer and pre-post processors in generated sample | Only applies with **Generate Parent Sample** on. When **off**, the parent sample measures the requests only: from the first one sent to the last response received, so think times and pre/post-processor time are reported as idle time instead of transaction time. When **on**, the parent sample spans the whole controller, pauses included (JMeter's Transaction Controller behaviour). | Off (`false`) |
 | Limit max number of parallel executions | When **off**, the cap is **`blazemeter.http.maxConcurrentAsyncInController`**. When **on**, cap is **Max parallel** (saved in the `.jmx` only while this is on; runtime still uses the global cap when off). | Off (`false`) |
 | Max parallel | Highest number of overlapping BlazeMeter HTTP samplers when limiting is **on** (integer ≥ **1**). Read-only when limiting is **off** (shows the effective global cap). | **100** (matches **`blazemeter.http.maxConcurrentAsyncInController`** unless you override; with limiting **on**, use the value you enter) |
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.blazemeter.jmeter</groupId>
   <artifactId>jmeter-bzm-http2</artifactId>
   <packaging>jar</packaging>
-  <version>3.1.1-SNAPSHOT</version>
+  <version>3.2.0</version>
   <name>BlazeMeter HTTP</name>
   <description>BlazeMeter HTTP Plugin for JMeter (HTTP/1.1, HTTP/2, HTTP/3/QUIC)</description>
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <jmeter.regression.external.tests>TestKeepAlive,TestRedirectionPolicies</jmeter.regression.external.tests>
     <jetty.version>12.1.11</jetty.version>
     <!-- Matches the log4j that JMeter 5.6.x ships in lib/, which provides the API at runtime. -->
-    <log4j.version>2.22.1</log4j.version>
+    <log4j.version>2.25.5</log4j.version>
     <!-- Matches jetty-project ${brotli4j.version} for Jetty 12.1.11 -->
     <brotli4j.version>1.23.0</brotli4j.version>
     <checkstyle.skip>false</checkstyle.skip>

--- a/src/main/java/com/blazemeter/jmeter/http2/control/HTTP2Controller.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/control/HTTP2Controller.java
@@ -1,5 +1,7 @@
 package com.blazemeter.jmeter.http2.control;
 
+import static com.blazemeter.jmeter.http2.core.LowLevelDebugLog.lowLevelDebug;
+
 import com.blazemeter.jmeter.http2.core.HTTP2FutureResponseListener;
 import com.blazemeter.jmeter.http2.core.SampleClock;
 import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
@@ -67,7 +69,11 @@ public class HTTP2Controller extends TransactionController implements Serializab
   private static final String COMPLETION_TIMEOUT_PROP =
       "httpJettyClient.asyncControllerCompletionTimeout";
   private static final long DEFAULT_COMPLETION_TIMEOUT_MILLIS = 120_000;
+  // New setting, so it carries the preferred name; getPropDefault still takes the legacy prefixes.
+  private static final String SCHEDULER_HOLD_PROP = "blazemeter.http.schedulerHoldMillis";
+  private static final long DEFAULT_SCHEDULER_HOLD_MILLIS = 2_000;
   private int maxConcurrentAsyncInController = DEFAULT_MAX_CONCURRENT_ASYNC_IN_CONTROLLER;
+  private long schedulerHoldMillis = DEFAULT_SCHEDULER_HOLD_MILLIS;
 
   private transient List<HTTP2Sampler> http2SamplesSync = new ArrayList<>();
   private transient boolean handingOutPendingSampler;
@@ -79,6 +85,13 @@ public class HTTP2Controller extends TransactionController implements Serializab
    * {@code super.triggerEndOfLoop()} returns.
    */
   private transient TransactionSampler openParentTransaction;
+  /**
+   * The thread's own scheduled end while this controller is holding it off, or {@code null} when it
+   * is not. See {@link #holdSchedulerWhileRequestsAreInFlight()}.
+   */
+  private transient Long heldSchedulerEndTime;
+  /** How many children the open transaction had when its span was last measured. */
+  private transient int measuredChildren;
 
   public HTTP2Controller() {
     super();
@@ -88,6 +101,7 @@ public class HTTP2Controller extends TransactionController implements Serializab
             String.valueOf(maxConcurrentAsyncInController)));
     generateControllerSample =
         BzmHttpPluginProperties.getControllerPropDefault(GENERATE_PARENT_SAMPLE_PREF, false);
+    schedulerHoldMillis = resolveSchedulerHoldMillis();
   }
 
   public void setLimitMaxParallel(boolean enabled) {
@@ -156,20 +170,122 @@ public class HTTP2Controller extends TransactionController implements Serializab
    */
   @Override
   public Sampler next() {
-    if (isGenerateParentSample()) {
-      Sampler next = super.next();
-      measureParentSample(next);
-      // Only after the controller has finished the parent transaction (next == null). Releasing
-      // while still returning the done TransactionSampler is pointless: JMeterThread calls
-      // configureTransactionSampler(done) next and puts that same instance back on the package.
-      // Releasing on the following null turn is what sticks — and runs after listeners/assertions
-      // in doEndTransactionSampler (same sequencing as JMeter PR #6386's TestCompiler.done() hook).
-      if (next == null) {
-        releaseCompletedParentTransactionSample();
+    try {
+      if (isGenerateParentSample()) {
+        Sampler next = super.next();
+        measureParentSample(next);
+        // Only after the controller has finished the parent transaction (next == null). Releasing
+        // while still returning the done TransactionSampler is pointless: JMeterThread calls
+        // configureTransactionSampler(done) next and puts that same instance back on the package.
+        // Releasing on the following null turn is what sticks — and runs after listeners/assertions
+        // in doEndTransactionSampler (same sequencing as JMeter PR #6386's TestCompiler.done()
+        // hook).
+        if (next == null) {
+          releaseCompletedParentTransactionSample();
+        }
+        return next;
       }
-      return next;
+      return nextWithoutTransactionBookkeeping();
+    } finally {
+      // After the turn, not before it: the request this turn dispatched is only on the wire once
+      // getCurrentElement has run, and what the scheduler checks right after this call returns is
+      // whether anything is out there now.
+      holdSchedulerWhileRequestsAreInFlight();
     }
-    return nextWithoutTransactionBookkeeping();
+  }
+
+  /**
+   * Keeps the thread's scheduled end from landing while this controller still has requests on the
+   * wire, and gives it back the moment they are all collected.
+   *
+   * <p>A stock sampler never loses a response to the schedule: {@code JMeterThread} checks the
+   * scheduled end in {@code stopSchedulerIfNeeded}, which runs after {@code executeSamplePackage}
+   * returns, so a request that is already out always gets to finish and be reported, and the
+   * transaction it belongs to closes with it inside. This controller has requests out across
+   * turns instead of inside one, so the same check lands between them: the thread stops with
+   * responses already on their way back, their samples are never reported, and the transaction they
+   * belonged to closes empty - a 0 ms row with no children, one per thread per run, which is enough
+   * to drag a label's Min to zero.
+   *
+   * <p>What is held off is only the scheduler's own deadline, through {@link JMeterThread}'s public
+   * end time, and only forward: a Stop, a shutdown or an interrupt do not go through it and are not
+   * affected. The push is small and renewed on every turn and on every completion poll, so the
+   * overrun is the time the pending responses need and nothing more; if this controller ever failed
+   * to give the deadline back, the last push expires on its own within
+   * {@code blazemeter.http.schedulerHoldMillis}.
+   *
+   * <p>Only the responses already asked for are waited on: once the real end has gone by,
+   * {@link #getCurrentElement()} stops dispatching the rest of the children rather than sending
+   * requests the run was over before making.
+   *
+   * <p>An empty queue is not the moment to give the deadline back: the response collected last has
+   * been handed to {@code JMeterThread} but not yet turned into a sample, and giving the deadline
+   * back on that same turn lets the scheduler stop the thread before it does - which loses exactly
+   * the response this was holding the thread for. The deadline goes back at the end of the
+   * iteration instead (see {@link #discardPendingAsyncSamples()}, reached through
+   * {@code reInitialize}), by which point every collected response has been reported; and since it
+   * stops being renewed as soon as the queue empties, a push left behind by any path that does not
+   * reach that point expires on its own.
+   */
+  private void holdSchedulerWhileRequestsAreInFlight() {
+    if (http2SamplesSync.isEmpty()) {
+      return;
+    }
+    JMeterThread thread = JMeterContextService.getContext().getThread();
+    if (thread == null || thread.getEndTime() <= 0) {
+      return; // Not a scheduled run: nothing is going to cut this thread short.
+    }
+    long hold = System.currentTimeMillis() + schedulerHoldMillis;
+    if (heldSchedulerEndTime == null) {
+      if (hold <= thread.getEndTime()) {
+        return; // The scheduled end is far enough away to collect what is out there.
+      }
+      heldSchedulerEndTime = thread.getEndTime();
+      lowLevelDebug("Holding the scheduled end of {} while {} request(s) are in flight in '{}'",
+          thread.getThreadName(), http2SamplesSync.size(), getName());
+    }
+    thread.setEndTime(hold);
+  }
+
+  /**
+   * Whether the thread's own scheduled end has already gone by while this controller was holding it
+   * off. Read from the end time that was saved, not from the thread, whose end time is the held one
+   * while the hold is on.
+   */
+  private boolean scheduledEndPassed() {
+    return heldSchedulerEndTime != null && System.currentTimeMillis() >= heldSchedulerEndTime;
+  }
+
+  /** Gives the thread back its own scheduled end, so the next check can stop it. */
+  private void releaseScheduler() {
+    if (heldSchedulerEndTime == null) {
+      return;
+    }
+    JMeterThread thread = JMeterContextService.getContext().getThread();
+    if (thread != null) {
+      thread.setEndTime(heldSchedulerEndTime);
+      lowLevelDebug("Scheduled end of {} restored: nothing left in flight in '{}'",
+          thread.getThreadName(), getName());
+    }
+    heldSchedulerEndTime = null;
+  }
+
+  /**
+   * Resolved once, at construction, like the other settings of this controller: this is read from
+   * the completion poll loop, which runs every {@value #COMPLETION_POLL_INTERVAL_MILLIS} ms for
+   * every thread that has a request out, and a JMeter property read is a synchronized map lookup
+   * per accepted name.
+   */
+  private static long resolveSchedulerHoldMillis() {
+    String configured = BzmHttpPluginProperties.getPropDefault(
+        SCHEDULER_HOLD_PROP, String.valueOf(DEFAULT_SCHEDULER_HOLD_MILLIS));
+    try {
+      return Math.max(0, Long.parseLong(configured.trim()));
+    } catch (NumberFormatException e) {
+      LOG.warn("Invalid {}='{}', falling back to {} ms", SCHEDULER_HOLD_PROP, configured,
+          DEFAULT_SCHEDULER_HOLD_MILLIS);
+      return DEFAULT_SCHEDULER_HOLD_MILLIS;
+    }
   }
 
   /**
@@ -183,32 +299,35 @@ public class HTTP2Controller extends TransactionController implements Serializab
    * the children instead, which double counts requests that ran at the same time. So the span is
    * measured here, out of the children's own stamps, exactly as this controller did up to v3.0.1.
    *
-   * <p>Also stamps an end time on a transaction that is still open. A transaction that never gets
-   * one reports {@code 0 - startTime}: {@code setTransactionDone} only stamps it in the
-   * "include timers" off branch, and {@code JMeterThread} does not call it at all when the run is
-   * cut short - the scheduler expiring, a manual Stop - it just ends the open transaction where it
-   * stands. An enclosing Transaction Controller then folds that result in through
-   * {@code SampleResult.addSubResult}, whose {@code Math.max} keeps the zero, and the enclosing
-   * sample comes out as a negative epoch that wrecks the Average and the Min of every aggregate
-   * over the run.
+   * <p>Measured on every turn, not only when the transaction is closed here, because it is not
+   * always closed here: {@code JMeterThread} ends whatever transaction is open when a run is cut
+   * short, without going through {@code setTransactionDone} and without asking this controller
+   * again. A transaction that has never been measured reports {@code 0 - startTime} - an epoch,
+   * which an enclosing Transaction Controller then folds in through
+   * {@code SampleResult.addSubResult}, whose {@code Math.max} keeps the zero - and one that was
+   * only measured when it closed would report, on that path, the wall clock this exists to correct.
+   * Keeping the open transaction measured as it goes means that however it ends, it already says
+   * what it ran.
    */
   private void measureParentSample(Sampler next) {
     if (!(next instanceof TransactionSampler)) {
       return;
     }
     TransactionSampler transactionSampler = (TransactionSampler) next;
-    if (transactionSampler.isTransactionDone()) {
-      openParentTransaction = null;
-      applyRequestSpan(transactionSampler);
+    openParentTransaction = transactionSampler.isTransactionDone() ? null : transactionSampler;
+    SampleResult parent = transactionSampler.getTransactionResult();
+    if (parent == null) {
       return;
     }
-    openParentTransaction = transactionSampler;
-    SampleResult parent = transactionSampler.getTransactionResult();
-    if (parent != null && parent.getEndTime() == 0) {
-      // Floor: a transaction ended from the outside now reports 0 ms instead of -startTime. Every
-      // child that arrives afterwards pushes it forward again through addSubResult's Math.max.
-      parent.setEndTime(parent.getStartTime());
+    // Only when there is something new to measure. A sample's stamps are final once it is reported,
+    // so the span can only move when a child joins - and walking every child on every turn of every
+    // request would be quadratic on a controller holding many of them.
+    int children = parent.getSubResults().length;
+    if (children == measuredChildren && parent.getEndTime() != 0) {
+      return;
     }
+    measuredChildren = children;
+    applyRequestSpan(transactionSampler);
   }
 
   /**
@@ -220,11 +339,16 @@ public class HTTP2Controller extends TransactionController implements Serializab
    * @see #isIncludeTimers()
    */
   private void applyRequestSpan(TransactionSampler transactionSampler) {
-    if (isIncludeTimers()) {
-      return;
-    }
     SampleResult parent = transactionSampler.getTransactionResult();
     if (parent == null) {
+      return;
+    }
+    if (isIncludeTimers()) {
+      if (parent.getEndTime() == 0) {
+        // The wall clock is what was asked for, but an end time there has to be: a transaction
+        // ended from the outside before its first child arrived would otherwise report the epoch.
+        parent.setEndTime(parent.getStartTime());
+      }
       return;
     }
     long firstStart = Long.MAX_VALUE;
@@ -448,7 +572,7 @@ public class HTTP2Controller extends TransactionController implements Serializab
       long deadline = System.currentTimeMillis() + timeout;
       while (!interrupted) {
         if (http2FListener.isDone() || http2FListener.isCancelled()) {
-          LOG.debug("HTTP Future Finished, retrying the sample with that data {}",
+          lowLevelDebug("HTTP Future Finished, retrying the sample with that data {}",
               describeRequest(http2FListener));
           return dequeueForCompletion(http2Sam);
         }
@@ -460,6 +584,9 @@ public class HTTP2Controller extends TransactionController implements Serializab
         }
         try {
           Thread.sleep(COMPLETION_POLL_INTERVAL_MILLIS);
+          // Renewed from inside the wait too: the scheduled end is only ever read between turns,
+          // and this loop is what makes a turn last as long as a response does.
+          holdSchedulerWhileRequestsAreInFlight();
         } catch (InterruptedException e) {
           http2SamplesSync.clear();
           interrupted = true;
@@ -509,7 +636,7 @@ public class HTTP2Controller extends TransactionController implements Serializab
 
   @Override
   protected TestElement getCurrentElement() throws NextIsNullException {
-    LOG.debug("Current {} Size {}", current, subControllersAndSamplers.size());
+    lowLevelDebug("Current {} Size {}", current, subControllersAndSamplers.size());
     handingOutPendingSampler = false;
 
     if (http2SamplesSync.size() > getEffectiveMaxConcurrentAsyncInController()) {
@@ -517,6 +644,16 @@ public class HTTP2Controller extends TransactionController implements Serializab
       if (!Objects.isNull(http2samDone)) {
         return handOutWithoutAdvancing(http2samDone);
       }
+    }
+
+    if (scheduledEndPassed()) {
+      // The run is over: collect what is already on the wire and end the iteration on it. Holding
+      // the thread alive is for the responses this controller already asked for, not a licence to
+      // keep asking - the remaining children would be load applied past the end of the test.
+      lowLevelDebug("Scheduled end reached with {} request(s) in flight in '{}'; collecting them "
+          + "and skipping the rest of the controller", http2SamplesSync.size(), getName());
+      HTTP2Sampler http2samDone = waitForDoneHTTP2();
+      return Objects.isNull(http2samDone) ? null : handOutWithoutAdvancing(http2samDone);
     }
 
     if (current < subControllersAndSamplers.size()) {
@@ -533,7 +670,7 @@ public class HTTP2Controller extends TransactionController implements Serializab
     }
     if (current == (subControllersAndSamplers.size())) {
       // On the last, force a checkpoint moment
-      LOG.debug("The last, force checkpoint");
+      lowLevelDebug("The last, force checkpoint");
       HTTP2Sampler http2samDone = waitForDoneHTTP2();
       if (!Objects.isNull(http2samDone)) {
         return handOutWithoutAdvancing(http2samDone);
@@ -545,7 +682,7 @@ public class HTTP2Controller extends TransactionController implements Serializab
   /** Switches a sampler to asynchronous mode and queues it for a later completion turn. */
   private HTTP2Sampler dispatchAsync(HTTP2Sampler sampler) {
     sampler.setSyncRequest(false); // Force to run async the first time
-    LOG.debug("Convert http2 sample to Async and add to wait list");
+    lowLevelDebug("Convert http2 sample to Async and add to wait list");
     http2SamplesSync.add(sampler);
     return sampler;
   }
@@ -618,6 +755,7 @@ public class HTTP2Controller extends TransactionController implements Serializab
    */
   private void discardPendingAsyncSamples() {
     if (http2SamplesSync.isEmpty()) {
+      releaseScheduler();
       return;
     }
     LOG.warn("Discarding {} in-flight async sample(s) left by an interrupted iteration of {}",
@@ -632,5 +770,8 @@ public class HTTP2Controller extends TransactionController implements Serializab
       pending.clearPendingSampleState();
     }
     http2SamplesSync.clear();
+    // Nothing is on the wire any more, so the thread gets its own scheduled end back even on the
+    // paths that gave up on the queue rather than draining it.
+    releaseScheduler();
   }
 }

--- a/src/main/java/com/blazemeter/jmeter/http2/control/HTTP2Controller.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/control/HTTP2Controller.java
@@ -1,6 +1,7 @@
 package com.blazemeter.jmeter.http2.control;
 
 import com.blazemeter.jmeter.http2.core.HTTP2FutureResponseListener;
+import com.blazemeter.jmeter.http2.core.SampleClock;
 import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
 import com.blazemeter.jmeter.http2.util.BzmHttpPluginProperties;
 import java.io.Serializable;
@@ -13,6 +14,7 @@ import org.apache.jmeter.control.Controller;
 import org.apache.jmeter.control.NextIsNullException;
 import org.apache.jmeter.control.TransactionController;
 import org.apache.jmeter.control.TransactionSampler;
+import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.JMeterProperty;
@@ -56,6 +58,8 @@ public class HTTP2Controller extends TransactionController implements Serializab
       BzmHttpPluginProperties.CONTROLLER_PREFERRED_PREFIX + "maxConcurrentAsyncInController";
   private static final String MAX_CONCURRENT_LEGACY =
       BzmHttpPluginProperties.CONTROLLER_LEGACY_PREFIX + "maxConcurrentAsyncInController";
+  /** JMeter's own property name, so a value set on a stock Transaction Controller still reads. */
+  private static final String INCLUDE_TIMERS = "TransactionController.includeTimers";
 
   private static final int DEFAULT_MAX_CONCURRENT_ASYNC_IN_CONTROLLER = 100;
   private static final long COMPLETION_POLL_INTERVAL_MILLIS = 10;
@@ -69,6 +73,12 @@ public class HTTP2Controller extends TransactionController implements Serializab
   private transient boolean handingOutPendingSampler;
   private transient boolean nestedSequentialRequestWarned;
   private boolean generateControllerSample;
+  /**
+   * The parent transaction currently open, so {@link #triggerEndOfLoop()} can still reach it: the
+   * field {@link TransactionController} keeps it in is private and is already null by the time
+   * {@code super.triggerEndOfLoop()} returns.
+   */
+  private transient TransactionSampler openParentTransaction;
 
   public HTTP2Controller() {
     super();
@@ -148,6 +158,7 @@ public class HTTP2Controller extends TransactionController implements Serializab
   public Sampler next() {
     if (isGenerateParentSample()) {
       Sampler next = super.next();
+      measureParentSample(next);
       // Only after the controller has finished the parent transaction (next == null). Releasing
       // while still returning the done TransactionSampler is pointless: JMeterThread calls
       // configureTransactionSampler(done) next and puts that same instance back on the package.
@@ -159,6 +170,128 @@ public class HTTP2Controller extends TransactionController implements Serializab
       return next;
     }
     return nextWithoutTransactionBookkeeping();
+  }
+
+  /**
+   * What the parent sample must report is the time this controller spent on requests, which for
+   * overlapped requests is the span from the first one leaving to the last one arriving.
+   *
+   * <p>Neither of {@link TransactionSampler}'s two modes measures that. With "include timers" on it
+   * leaves the sample stretching from the moment the transaction opened - before the timers and
+   * pre-processors of the first request ran - to the last response, so a think time lands inside
+   * the transaction time (issue #155). With it off, {@code setTransactionDone} reports the sum of
+   * the children instead, which double counts requests that ran at the same time. So the span is
+   * measured here, out of the children's own stamps, exactly as this controller did up to v3.0.1.
+   *
+   * <p>Also stamps an end time on a transaction that is still open. A transaction that never gets
+   * one reports {@code 0 - startTime}: {@code setTransactionDone} only stamps it in the
+   * "include timers" off branch, and {@code JMeterThread} does not call it at all when the run is
+   * cut short - the scheduler expiring, a manual Stop - it just ends the open transaction where it
+   * stands. An enclosing Transaction Controller then folds that result in through
+   * {@code SampleResult.addSubResult}, whose {@code Math.max} keeps the zero, and the enclosing
+   * sample comes out as a negative epoch that wrecks the Average and the Min of every aggregate
+   * over the run.
+   */
+  private void measureParentSample(Sampler next) {
+    if (!(next instanceof TransactionSampler)) {
+      return;
+    }
+    TransactionSampler transactionSampler = (TransactionSampler) next;
+    if (transactionSampler.isTransactionDone()) {
+      openParentTransaction = null;
+      applyRequestSpan(transactionSampler);
+      return;
+    }
+    openParentTransaction = transactionSampler;
+    SampleResult parent = transactionSampler.getTransactionResult();
+    if (parent != null && parent.getEndTime() == 0) {
+      // Floor: a transaction ended from the outside now reports 0 ms instead of -startTime. Every
+      // child that arrives afterwards pushes it forward again through addSubResult's Math.max.
+      parent.setEndTime(parent.getStartTime());
+    }
+  }
+
+  /**
+   * Rewrites the finished parent sample as {@code lastResponse - firstRequestSent}, leaving what
+   * came before the first request (timers, pre-processors) in {@code idleTime}, which is the field
+   * JMeter itself uses for it. Keeps the wall clock reading when the user asked for the timers to
+   * be included.
+   *
+   * @see #isIncludeTimers()
+   */
+  private void applyRequestSpan(TransactionSampler transactionSampler) {
+    if (isIncludeTimers()) {
+      return;
+    }
+    SampleResult parent = transactionSampler.getTransactionResult();
+    if (parent == null) {
+      return;
+    }
+    long firstStart = Long.MAX_VALUE;
+    long lastEnd = 0;
+    for (SampleResult child : parent.getSubResults()) {
+      // Each child's stamps are on its own clock, put on the transaction's the same way
+      // SampleResult.addSubResult does when it extends a parent's end time (Bug 51855).
+      if (child.getStartTime() > 0) {
+        firstStart = Math.min(firstStart,
+            SampleClock.fromResultClock(parent, child, child.getStartTime()));
+      }
+      if (child.getEndTime() > 0) {
+        lastEnd = Math.max(lastEnd,
+            SampleClock.fromResultClock(parent, child, child.getEndTime()));
+      }
+    }
+    if (firstStart == Long.MAX_VALUE || lastEnd < firstStart) {
+      // Nothing was measured: an iteration that was cut short, or children that never got stamps.
+      parent.setIdleTime(0);
+      parent.setEndTime(parent.getStartTime());
+      return;
+    }
+    // elapsed = endTime - startTime - idleTime, so this reads exactly lastEnd - firstStart. Going
+    // through idleTime rather than a synthetic end time leaves the sample ending when its last
+    // request did, and holding what came before the first one in the field JMeter's own Transaction
+    // Controller keeps a pause in (Bug 50080).
+    parent.setIdleTime(firstStart - parent.getStartTime());
+    parent.setEndTime(lastEnd);
+  }
+
+  /**
+   * The children of an aborted iteration - Start Next Loop, Stop Thread - are attached by
+   * {@code super.triggerEndOfLoop()}, which also closes the transaction, so the span can only be
+   * measured after it.
+   */
+  @Override
+  public void triggerEndOfLoop() {
+    TransactionSampler ending = openParentTransaction;
+    openParentTransaction = null;
+    super.triggerEndOfLoop();
+    if (ending != null) {
+      applyRequestSpan(ending);
+    }
+  }
+
+  /**
+   * Same question a stock Transaction Controller asks, with the opposite default: a think time is a
+   * pause, not request time, and this controller has never counted it. Answering {@code true} by
+   * inheritance - which is what JMeter's own default does, for compatibility with test plans older
+   * than its checkbox - is what put the think time inside the transaction time in v3.1.0. An
+   * explicit value, from this element's GUI or from a JMX written against a stock Transaction
+   * Controller, is honoured.
+   */
+  @Override
+  public boolean isIncludeTimers() {
+    return containsElementPropertyNamed(INCLUDE_TIMERS)
+        && getPropertyAsBoolean(INCLUDE_TIMERS, false);
+  }
+
+  /**
+   * Always writes the property. {@code TransactionController.setIncludeTimers} drops it when it
+   * matches JMeter's default of {@code true}, which would leave this controller reading its own
+   * default of {@code false} and silently discard the user's choice.
+   */
+  @Override
+  public void setIncludeTimers(boolean includeTimers) {
+    setProperty(INCLUDE_TIMERS, includeTimers);
   }
 
   /**

--- a/src/main/java/com/blazemeter/jmeter/http2/control/gui/HTTP2ControllerGUI.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/control/gui/HTTP2ControllerGUI.java
@@ -18,12 +18,15 @@ import org.apache.jmeter.testelement.TestElement;
 public class HTTP2ControllerGUI extends AbstractControllerGui implements Scrollable {
   private static final long serialVersionUID = 240L;
   private final JCheckBox generateControllerSample;
+  private final JCheckBox includeTimers;
   private final JCheckBox limitMaxParallel;
   private final JTextField maxParallelField;
   private int defaultMaxParallel;
 
   public HTTP2ControllerGUI() {
     generateControllerSample = new JCheckBox("Generate Parent Sample");
+    includeTimers = new JCheckBox(
+        "Include duration of timer and pre-post processors in generated sample");
     limitMaxParallel = new JCheckBox("Limit max number of parallel executions");
     maxParallelField = new JTextField(8);
     init();
@@ -47,6 +50,7 @@ public class HTTP2ControllerGUI extends AbstractControllerGui implements Scrolla
     if (el instanceof HTTP2Controller) {
       HTTP2Controller controller = (HTTP2Controller) el;
       controller.setGenerateControllerSample(generateControllerSample.isSelected());
+      controller.setIncludeTimers(includeTimers.isSelected());
       controller.setLimitMaxParallel(limitMaxParallel.isSelected());
       if (limitMaxParallel.isSelected()) {
         controller.setMaxConcurrentAsyncInController(parseMaxParallelValue());
@@ -60,6 +64,8 @@ public class HTTP2ControllerGUI extends AbstractControllerGui implements Scrolla
     if (element instanceof HTTP2Controller) {
       HTTP2Controller controller = (HTTP2Controller) element;
       generateControllerSample.setSelected(controller.isGenerateControllerSample());
+      includeTimers.setSelected(controller.isIncludeTimers());
+      updateIncludeTimersState(controller.isGenerateControllerSample());
       limitMaxParallel.setSelected(controller.isLimitMaxParallel());
       maxParallelField.setText(String.valueOf(controller.getMaxConcurrentAsyncInController()));
       updateMaxParallelFieldState(controller);
@@ -77,6 +83,11 @@ public class HTTP2ControllerGUI extends AbstractControllerGui implements Scrolla
     setBorder(makeBorder());
     add(makeTitlePanel(), BorderLayout.NORTH);
     add(buildOptionsPanel(), BorderLayout.CENTER);
+
+    // The timer question only exists for the sample this controller generates itself: with no
+    // parent sample there is nothing whose duration could include them.
+    generateControllerSample.addItemListener(
+        event -> updateIncludeTimersState(event.getStateChange() == ItemEvent.SELECTED));
 
     limitMaxParallel.addItemListener(event -> {
       boolean enabled = event.getStateChange() == ItemEvent.SELECTED;
@@ -99,6 +110,9 @@ public class HTTP2ControllerGUI extends AbstractControllerGui implements Scrolla
     generateControllerSample.setAlignmentX(JCheckBox.LEFT_ALIGNMENT);
     panel.add(generateControllerSample);
 
+    includeTimers.setAlignmentX(JCheckBox.LEFT_ALIGNMENT);
+    panel.add(includeTimers);
+
     limitMaxParallel.setAlignmentX(JCheckBox.LEFT_ALIGNMENT);
     panel.add(limitMaxParallel);
 
@@ -108,6 +122,10 @@ public class HTTP2ControllerGUI extends AbstractControllerGui implements Scrolla
     panel.add(maxRow);
 
     return panel;
+  }
+
+  private void updateIncludeTimersState(boolean generatesParentSample) {
+    includeTimers.setEnabled(generatesParentSample);
   }
 
   private void updateMaxParallelFieldState(HTTP2Controller controller) {

--- a/src/main/java/com/blazemeter/jmeter/http2/core/ConnectAttemptRecorder.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/ConnectAttemptRecorder.java
@@ -1,0 +1,232 @@
+package com.blazemeter.jmeter.http2.core;
+
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.URL;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import javax.net.ssl.SSLException;
+import org.eclipse.jetty.client.Connection;
+import org.eclipse.jetty.util.Promise;
+
+/**
+ * Keeps the connection failures Jetty throws away, so a failed sample can report every address it
+ * actually tried instead of only the last one.
+ *
+ * <p>{@code HttpClient.connect(List, int, Map)} walks the resolved addresses recursively and, when
+ * one fails, calls itself for the next while <em>discarding</em> the exception - no
+ * {@code addSuppressed}, no log. Only the last address's failure survives. With the JDK default
+ * ({@code java.net.preferIPv6Addresses=false}) IPv4 is tried first, so a dual-stack host that
+ * fails on both reports the IPv6 error alone and the IPv4 one - usually the interesting one - is
+ * gone. Same code in 12.0.x and 12.1.x, so this is not a version regression.
+ *
+ * <p>The recovery point is {@code Connection.PROMISE_CONTEXT_KEY}: the promise Jetty puts in the
+ * context for one address, whose {@code failed} is exactly what decides to move on to the next.
+ * <em>Every</em> way of failing to establish a connection ends there - a refused socket, a TLS
+ * handshake, ALPN, and the HTTP/2 preface, since
+ * {@code HTTPSessionListenerPromise.failConnectionPromise} fails that same promise. Wrapping it
+ * in {@link #instrument} therefore covers all of them at once, with the address in hand, and
+ * without depending on per-phase listeners that each see only their own slice.
+ *
+ * <p>The recovered failures are attached to the sample's failure as <em>suppressed</em>
+ * exceptions: {@code HTTPSamplerBase.errorResult} writes {@code printStackTrace} into the response
+ * data, and that prints suppressed entries, so they show up in View Results Tree with no new
+ * formatting and without going through SLF4J - which the shaded jar has no provider for.
+ */
+public class ConnectAttemptRecorder {
+
+  /**
+   * Recent failures kept per client. A run that cannot connect at all would otherwise grow this
+   * without bound; the last few are all a failing sample can use, since it only reads the ones
+   * recorded while it was running.
+   */
+  private static final int DEFAULT_CAPACITY = 64;
+
+  /** Cap on how many attempts are attached to a single failure, to keep the trace readable. */
+  private static final int MAX_ATTACHED = 8;
+
+  private static final String TCP_PHASE = "Connect to";
+  private static final String TLS_PHASE = "TLS handshake with";
+  private static final String SESSION_PHASE = "Connection to";
+
+  private final int capacity;
+  private final Deque<FailedAttempt> attempts = new ArrayDeque<>();
+
+  public ConnectAttemptRecorder() {
+    this(DEFAULT_CAPACITY);
+  }
+
+  public ConnectAttemptRecorder(int capacity) {
+    this.capacity = capacity;
+  }
+
+  /**
+   * Wraps the per-address connection promise in {@code context} so this recorder sees its failure
+   * before Jetty decides to move on to the next address.
+   *
+   * <p>Called from the transport's {@code connect(SocketAddress, Map)}, which Jetty invokes once
+   * per resolved address with the promise for that address already in the context. Replacing it
+   * here is safe because everything downstream reads it back out of the context by key:
+   * {@code HttpClient.connect} binds {@code CONNECTION_PROMISE_CONTEXT_KEY} to it, and the HTTP/2
+   * session listener resolves it lazily through {@code httpConnectionPromise()}.
+   */
+  public void instrument(SocketAddress address, Map<String, Object> context) {
+    if (!(address instanceof InetSocketAddress) || context == null) {
+      return;
+    }
+    @SuppressWarnings("unchecked")
+    Promise<Connection> promise =
+        (Promise<Connection>) context.get(Connection.PROMISE_CONTEXT_KEY);
+    if (promise == null) {
+      return;
+    }
+    InetSocketAddress inetAddress = (InetSocketAddress) address;
+    context.put(Connection.PROMISE_CONTEXT_KEY, new Promise.Wrapper<Connection>(promise) {
+      @Override
+      public void failed(Throwable failure) {
+        record(inetAddress, failure);
+        super.failed(failure);
+      }
+    });
+  }
+
+  /**
+   * Attaches to {@code target} every connection failure recorded for {@code url}'s origin while
+   * the sample was running.
+   *
+   * <p>Filtering by start time is what keeps the attribution honest without tracking which sample
+   * owns which socket: connects run on Jetty threads, and concurrent embedded resources share the
+   * client, so time plus origin is the correlation available. Attempts are attached as suppressed
+   * exceptions whose cause is the original failure, keeping its stack trace intact.
+   *
+   * @param target the failure about to be reported for the sample
+   * @param url the sampled URL, used to match host and port
+   * @param sinceMillis the sample start, in epoch milliseconds; {@code 0} takes everything held
+   */
+  public void attachTo(Throwable target, URL url, long sinceMillis) {
+    if (target == null || url == null) {
+      return;
+    }
+    for (FailedAttempt attempt : failuresFor(url, sinceMillis)) {
+      // The attempt that survived Jetty's loop is already the cause of what is being reported;
+      // attaching it again would duplicate it and make printStackTrace emit a
+      // "[CIRCULAR REFERENCE]" marker. Only the discarded ones are missing.
+      if (!isInCauseChain(target, attempt.failure)) {
+        target.addSuppressed(new ConnectAttemptFailure(attempt));
+      }
+    }
+  }
+
+  private void record(InetSocketAddress address, Throwable failure) {
+    synchronized (attempts) {
+      attempts.addLast(new FailedAttempt(address, failure, System.currentTimeMillis()));
+      while (attempts.size() > capacity) {
+        attempts.removeFirst();
+      }
+    }
+  }
+
+  private static boolean isInCauseChain(Throwable target, Throwable failure) {
+    for (Throwable current = target; current != null; current = current.getCause()) {
+      if (current == failure) {
+        return true;
+      }
+      if (current.getCause() == current) {
+        break;
+      }
+    }
+    return false;
+  }
+
+  private List<FailedAttempt> failuresFor(URL url, long sinceMillis) {
+    String host = url.getHost();
+    if (host == null || host.isEmpty()) {
+      return List.of();
+    }
+    int port = url.getPort() >= 0 ? url.getPort() : url.getDefaultPort();
+    List<FailedAttempt> matches = new ArrayList<>();
+    synchronized (attempts) {
+      for (FailedAttempt attempt : attempts) {
+        if (attempt.matches(host, port, sinceMillis)) {
+          matches.add(attempt);
+        }
+      }
+    }
+    if (matches.size() > MAX_ATTACHED) {
+      return matches.subList(matches.size() - MAX_ATTACHED, matches.size());
+    }
+    return matches;
+  }
+
+  /**
+   * Names the stage the attempt died at, from the failure itself. The cause is printed underneath
+   * anyway, so this is a label rather than a diagnosis - which is what makes deriving it cheaper
+   * than wiring one listener per phase.
+   */
+  private static String phaseOf(Throwable failure) {
+    for (Throwable current = failure; current != null; current = current.getCause()) {
+      if (current instanceof SSLException) {
+        return TLS_PHASE;
+      }
+      if (current instanceof SocketException || current instanceof SocketTimeoutException
+          || current instanceof ConnectException) {
+        return TCP_PHASE;
+      }
+      if (current.getCause() == current) {
+        break;
+      }
+    }
+    return SESSION_PHASE;
+  }
+
+  private static final class FailedAttempt {
+
+    private final InetSocketAddress address;
+    private final Throwable failure;
+    private final long timestamp;
+
+    private FailedAttempt(InetSocketAddress address, Throwable failure, long timestamp) {
+      this.address = address;
+      this.failure = failure;
+      this.timestamp = timestamp;
+    }
+
+    private boolean matches(String host, int port, long sinceMillis) {
+      if (address.getPort() != port || timestamp < sinceMillis) {
+        return false;
+      }
+      // getHostString() carries the name the address was resolved from and never triggers a
+      // reverse lookup, so this stays off the network even for a literal-IP URL.
+      return address.getHostString().toLowerCase(Locale.ROOT).equals(host.toLowerCase(Locale.ROOT));
+    }
+
+    private String describe() {
+      String ip = address.getAddress() != null
+          ? address.getAddress().getHostAddress()
+          : address.getHostString();
+      return phaseOf(failure) + " " + address.getHostString() + "/" + ip + ":" + address.getPort()
+          + " failed";
+    }
+  }
+
+  /**
+   * Carrier for one discarded attempt. Its own stack trace is deliberately not filled in: the
+   * frames that matter belong to the cause, and this exception is never thrown - it exists only to
+   * be printed under {@code Suppressed:}.
+   */
+  public static class ConnectAttemptFailure extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    private ConnectAttemptFailure(FailedAttempt attempt) {
+      super(attempt.describe(), attempt.failure, true, false);
+    }
+  }
+}

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListener.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListener.java
@@ -8,6 +8,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
+import java.util.OptionalLong;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -15,6 +16,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.jmeter.samplers.SampleResult;
 import org.eclipse.jetty.client.AbstractResponseListener;
 import org.eclipse.jetty.client.BufferingResponseListener;
 import org.eclipse.jetty.client.ContentResponse;
@@ -48,8 +50,14 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
    * origin, while the competing attempt still serves the request. See {@link #onComplete}.
    */
   private volatile String raceProtocol;
-  private long responseStart;
-  private long responseEnd;
+  /**
+   * When the request went out and when it completed. Written on a Jetty thread and read on the
+   * JMeter one, so each end is a single immutable value published through one volatile write:
+   * whoever reads a {@link Stamp} sees all of it, and never a wall-clock reading paired with a
+   * monotonic one that has not been taken yet.
+   */
+  private volatile Stamp responseStartStamp;
+  private volatile Stamp responseEndStamp;
   /**
    * {@link #releaseTransportBuffers()} is invoked from several completion paths (wrapper build,
    * sealed HE abort {@code onFailure}/{@code onComplete}, {@code cancel}, sample materialisation).
@@ -91,21 +99,62 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
   }
 
   protected void setStart() {
-    if (this.responseStart == 0) {
-      this.responseStart = System.currentTimeMillis();
+    if (this.responseStartStamp == null) {
+      this.responseStartStamp = Stamp.now();
     }
   }
 
   protected void setEnd() {
-    this.responseEnd = System.currentTimeMillis();
+    this.responseEndStamp = Stamp.now();
   }
 
+  /**
+   * When the request went out as a {@link System#currentTimeMillis()} time, or 0. An absolute time
+   * to report or to log; to stamp it on a sample use {@link #getResponseStartOn}, and to measure a
+   * wait from it use {@link #getResponseStartNanos}.
+   */
   public long getResponseStart() {
-    return this.responseStart;
+    return Stamp.wallClockOf(this.responseStartStamp);
   }
 
+  /**
+   * When the exchange completed as a {@link System#currentTimeMillis()} time, or 0. See
+   * {@link #getResponseStart()} for which of these three readings to use.
+   */
   public long getResponseEnd() {
-    return this.responseEnd;
+    return Stamp.wallClockOf(this.responseEndStamp);
+  }
+
+  /**
+   * The {@link System#nanoTime()} reading of when the request went out, empty only when the request
+   * never went out at all.
+   *
+   * <p>For measuring how long something has been waiting, which must not be thrown off by the
+   * machine clock moving under it.
+   */
+  public OptionalLong getResponseStartNanos() {
+    Stamp stamp = this.responseStartStamp;
+    return stamp == null ? OptionalLong.empty() : OptionalLong.of(stamp.nanoTime);
+  }
+
+  /**
+   * When the request went out, on {@code result}'s own clock, or 0 when that was never recorded.
+   *
+   * <p>This, and never {@link #getResponseStart()}, is what a {@link SampleResult} must be stamped
+   * from: a sample whose start comes from {@code sampleStart()} and whose end comes from the wall
+   * clock reports the distance between those two clocks as part of its duration. See
+   * {@link SampleClock}.
+   */
+  public long getResponseStartOn(SampleResult result) {
+    return Stamp.on(result, this.responseStartStamp);
+  }
+
+  /**
+   * When the exchange completed, on {@code result}'s own clock, or 0 when that was never recorded.
+   * See {@link #getResponseStartOn}.
+   */
+  public long getResponseEndOn(SampleResult result) {
+    return Stamp.on(result, this.responseEndStamp);
   }
 
   /**
@@ -120,13 +169,36 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
    * synchronous caller never noticed because it returns the winner directly instead of reading back
    * from here; a consumer that polls {@link #isDone()} and then calls {@link #get()} does.
    */
+  public void completeWith(ContentResponse response, HTTP2FutureResponseListener source) {
+    if (source.responseStartStamp != null) {
+      this.responseStartStamp = source.responseStartStamp;
+    }
+    this.responseEndStamp =
+        source.responseEndStamp != null ? source.responseEndStamp : Stamp.now();
+    seal(response);
+  }
+
+  /**
+   * Adopts a result timed only on the wall clock. Prefer
+   * {@link #completeWith(ContentResponse, HTTP2FutureResponseListener)}, which is what the protocol
+   * race uses: it carries the winner's monotonic readings over as well, so the sample stamped from
+   * this listener is translated from the exchange it actually reports.
+   */
   public void completeWith(ContentResponse response, long responseStart, long responseEnd) {
+    if (responseStart > 0) {
+      // These stamps describe another exchange, so this listener's own monotonic readings do not
+      // match them and must not be used to translate them.
+      this.responseStartStamp = Stamp.ofWallClock(responseStart);
+    }
+    this.responseEndStamp =
+        responseEnd > 0 ? Stamp.ofWallClock(responseEnd) : Stamp.now();
+    seal(response);
+  }
+
+  /** Stores the adopted response and seals this listener: common tail of {@code completeWith}. */
+  private void seal(ContentResponse response) {
     this.response = response;
     this.failure = null;
-    if (responseStart > 0) {
-      this.responseStart = responseStart;
-    }
-    this.responseEnd = responseEnd > 0 ? responseEnd : System.currentTimeMillis();
     this.onCompleteCalled = true;
     this.sealed = true;
     // Drop any partial body this listener may have buffered for its own (losing) attempt — the
@@ -585,5 +657,59 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
     return response;
   }
 
+  /**
+   * One instant of the exchange, read on both clocks at once so a consumer can pick the one it
+   * needs: the wall clock to report an absolute time, the monotonic reading to measure a duration
+   * or to translate the instant onto a {@link SampleResult}'s clock.
+   *
+   * <p>Immutable, so publishing it through a single volatile field is enough for a JMeter thread to
+   * see a whole instant rather than half of one written by a Jetty thread.
+   */
+  private static final class Stamp {
+
+    private final long wallClockMillis;
+    private final long nanoTime;
+    /** Whether {@link #nanoTime} belongs to this instant, rather than never having been taken. */
+    private final boolean monotonic;
+
+    private Stamp(long wallClockMillis, long nanoTime, boolean monotonic) {
+      this.wallClockMillis = wallClockMillis;
+      this.nanoTime = nanoTime;
+      this.monotonic = monotonic;
+    }
+
+    private static Stamp now() {
+      // The monotonic reading first: it is the one this instant gets translated with, the wall
+      // clock one is only ever reported as it is.
+      long nanoTime = System.nanoTime();
+      return new Stamp(System.currentTimeMillis(), nanoTime, true);
+    }
+
+    /**
+     * An instant known only as a wall-clock time, adopted from another exchange. Its monotonic
+     * counterpart is derived from how long ago it was, so measuring a wait from it still works;
+     * {@code monotonic} stays false because the derivation already went through the wall clock and
+     * translating it again would compound the two conversions.
+     */
+    private static Stamp ofWallClock(long wallClockMillis) {
+      long nanoTime = System.nanoTime()
+          - TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis() - wallClockMillis);
+      return new Stamp(wallClockMillis, nanoTime, false);
+    }
+
+    private static long wallClockOf(Stamp stamp) {
+      return stamp == null ? 0 : stamp.wallClockMillis;
+    }
+
+    /** This instant on {@code result}'s own clock, or 0 when there is no instant. */
+    private static long on(SampleResult result, Stamp stamp) {
+      if (stamp == null) {
+        return 0;
+      }
+      return stamp.monotonic
+          ? SampleClock.fromNanoTime(result, stamp.nanoTime)
+          : SampleClock.fromWallClock(result, stamp.wallClockMillis);
+    }
+  }
 }
 

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListener.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListener.java
@@ -348,14 +348,14 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
         // The losing side of a resolved protocol race, or an explicit cancel(): expected, and the
         // winner's response is reported elsewhere. Logging it as an error filled the log with
         // failures that are not failures, one per raced request.
-        LOG.debug("{} attempt cancelled: {}",
+        lowLevelDebug("{} attempt cancelled: {}",
             raceProtocol != null ? raceProtocol : "Request", failure.getMessage());
       } else if (raceProtocol != null) {
         // One side of a race failing on its own is the expected outcome when the origin does not
         // support that protocol: the other attempt serves the request, and the race only gives up
         // once both sides fail - at which point the caller reports the real failure. Saying "not
         // negotiated" rather than "failed" keeps this from reading as a broken request.
-        LOG.debug("{} not negotiated for {}: {}", raceProtocol,
+        lowLevelDebug("{} not negotiated for {}: {}", raceProtocol,
             request != null ? request.getURI() : "unknown", failure.getMessage());
       } else {
         // Internal transport detail; raise the logger to DEBUG to diagnose. The caller still
@@ -461,7 +461,7 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
 
   @Override
   public boolean cancel(boolean mayInterruptIfRunning) {
-    LOG.debug("=== cancel() called ===");
+    lowLevelDebug("=== cancel() called ===");
     cancelled = true;
     // In Jetty 12, abort() returns CompletableFuture<Boolean>
     if (request != null) {

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -88,6 +88,7 @@ import org.eclipse.jetty.client.BasicAuthentication;
 import org.eclipse.jetty.client.BytesRequestContent;
 import org.eclipse.jetty.client.ContentDecoder;
 import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.Destination;
 import org.eclipse.jetty.client.DigestAuthentication;
 import org.eclipse.jetty.client.FormRequestContent;
 import org.eclipse.jetty.client.HttpClient;
@@ -132,6 +133,7 @@ import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.ClientConnectionFactory;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.Transport;
 import org.eclipse.jetty.io.ssl.SslConnection;
 import org.eclipse.jetty.io.ssl.SslHandshakeListener;
@@ -468,7 +470,7 @@ public class HTTP2JettyClient {
     }
 
     CustomClientConnectionFactoryOverHTTP2.HTTP2 http2 =
-        new CustomClientConnectionFactoryOverHTTP2.HTTP2(http2Client);
+        new CustomClientConnectionFactoryOverHTTP2.HTTP2(http2Client, this::onHttp2Rejected);
 
     // Configure server push (can be disabled for compatibility)
     if (disableServerPush) {
@@ -2128,7 +2130,8 @@ public class HTTP2JettyClient {
           throw e;
         }
       }
-      if (shouldFallbackToHttp11AfterTransportFailure(cause, e)) {
+      if (shouldFallbackToHttp11AfterTransportFailure(cause, e)
+          || shouldFallbackToHttp11AfterHttp2Rejected(request.getURI())) {
         LOG.warn("Transport failure detected in send()! Attempting fallback to HTTP/1.1");
         LOG.warn("Error details: message='{}', exception={}",
             cause != null ? cause.getMessage() : e.getMessage(),
@@ -3105,6 +3108,28 @@ public class HTTP2JettyClient {
     }
   }
 
+  /**
+   * Records that an origin does not speak HTTP/2 at all, so every later sample to it goes straight
+   * to HTTP/1.1 instead of paying a failed HTTP/2 attempt per resolved address.
+   *
+   * <p>Reported by {@code CustomHttpSessionListenerPromise} only when the session died before the
+   * server preface arrived, which is what separates "this peer cannot speak HTTP/2" from a healthy
+   * session being closed. The usual cause is a TLS handshake that selected no ALPN protocol -
+   * Jetty then falls back to the first configured protocol, which is HTTP/2 - and it is worth
+   * remembering because Jetty treats each rejected attempt as a failed connection and rolls over
+   * to the next address, burning every usable one before reporting whatever the last address said.
+   */
+  private void onHttp2Rejected(URI origin) {
+    if (!enableHttp1 || !http1OnlyCacheEnabled || http1OnlyCooldownMs <= 0 || origin == null) {
+      lowLevelDebug("Origin {} rejected the HTTP/2 preface but will not be remembered "
+              + "(enableHttp1={}, http1OnlyCacheEnabled={}, cooldownMs={})",
+          origin, enableHttp1, http1OnlyCacheEnabled, http1OnlyCooldownMs);
+      return;
+    }
+    lowLevelDebug("Origin {} rejected the HTTP/2 preface; remembering it as HTTP/1.1-only", origin);
+    markHttp1OnlyOrigin(originKey(origin));
+  }
+
   private void markHttp1OnlyOrigin(String origin) {
     Http1OnlyEntry entry = new Http1OnlyEntry();
     entry.expiresAt = System.currentTimeMillis() + http1OnlyCooldownMs;
@@ -3240,6 +3265,21 @@ public class HTTP2JettyClient {
     return ProtocolErrorException.isProtocolError(wrapped)
         || ProtocolErrorException.isProtocolError(cause)
         || isClosedChannelFailure(cause != null ? cause : wrapped);
+  }
+
+  /**
+   * Whether this failure should be retried over HTTP/1.1 because the origin turned out not to
+   * speak HTTP/2 while this very request was being attempted.
+   *
+   * <p>Needed on top of {@link #shouldFallbackToHttp11AfterTransportFailure} because the exception
+   * that reaches the caller is whatever the <em>last</em> resolved address produced, and Jetty
+   * discards the earlier ones. An origin whose usable addresses all rejected the HTTP/2 preface
+   * therefore surfaces as a plain socket error from some later, unrelated address: a host that
+   * resolves to several reachable addresses followed by unreachable ones fails the preface on
+   * each reachable one, and then reports whatever the first unreachable one said.
+   */
+  private boolean shouldFallbackToHttp11AfterHttp2Rejected(URI uri) {
+    return protocolErrorFallbackEnabled && enableHttp1 && uri != null && isHttp1Only(uri);
   }
 
   private static boolean isClosedChannelFailure(Throwable throwable) {
@@ -3382,15 +3422,64 @@ public class HTTP2JettyClient {
    */
   private class RecordingHttpClientTransportDynamic extends HttpClientTransportDynamic {
 
+    private final ClientConnectionFactory.Info[] infos;
+
     RecordingHttpClientTransportDynamic(ClientConnector connector,
                                         ClientConnectionFactory.Info... infos) {
       super(connector, infos);
+      this.infos = infos;
     }
 
     @Override
     public void connect(SocketAddress address, Map<String, Object> context) {
       connectAttempts.instrument(address, context);
       super.connect(address, context);
+    }
+
+    /**
+     * Stops re-offering HTTP/2 to an origin already known to reject it, address after address.
+     *
+     * <p>Jetty resolves the connection factory once per resolved address, so without this the
+     * first rejection is paid again on every remaining address of the same request: each one
+     * completes TCP and TLS, gets the preface refused, and counts as a failed connection attempt
+     * that rolls over to the next. Consulting what {@link #onHttp2Rejected} already learned turns
+     * that into a single wasted connection for the whole origin.
+     *
+     * <p>Deliberately keyed on that knowledge rather than on the negotiated ALPN protocol: at this
+     * point the TLS handshake has not run yet, so neither the context nor the {@code SSLEngine}
+     * knows what was agreed, and an origin that does speak HTTP/2 never reaches this branch
+     * because nothing ever marks it.
+     */
+    @Override
+    public Connection newConnection(EndPoint endPoint, Map<String, Object> context)
+        throws IOException {
+      ClientConnectionFactory.Info http11 = http11ForOriginThatRejectedHttp2(context);
+      if (http11 != null) {
+        return http11.getClientConnectionFactory().newConnection(endPoint, context);
+      }
+      return super.newConnection(endPoint, context);
+    }
+
+    private ClientConnectionFactory.Info http11ForOriginThatRejectedHttp2(
+        Map<String, Object> context) {
+      if (!enableHttp1) {
+        return null;
+      }
+      Destination destination = (Destination) context.get(Destination.CONTEXT_KEY);
+      if (destination == null) {
+        return null;
+      }
+      URI origin = URI.create(destination.getOrigin().asString());
+      if (!isHttp1Only(origin)) {
+        return null;
+      }
+      lowLevelDebug("Origin {} is known to reject HTTP/2; using HTTP/1.1 for this address", origin);
+      for (ClientConnectionFactory.Info info : infos) {
+        if (info.getProtocols(destination.isSecure()).contains("http/1.1")) {
+          return info;
+        }
+      }
+      return null;
     }
   }
 

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -60,6 +60,7 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.conn.DnsResolver;
 import org.apache.jmeter.protocol.http.control.AuthManager;
 import org.apache.jmeter.protocol.http.control.Authorization;
 import org.apache.jmeter.protocol.http.control.Cookie;
@@ -317,6 +318,12 @@ public class HTTP2JettyClient {
    * {@code findAuthentication} (realm/URI matching quirks) and prevents per-sample list growth.
    */
   private final Set<String> registeredAuthFingerprints = ConcurrentHashMap.newKeySet();
+  /**
+   * The sampler's DNS Cache Manager, or {@code null} when the plan has none. Held so
+   * {@link #configureHttpClient} can install {@link JMeterDnsSocketAddressResolver} on every
+   * protocol-variant client before any of them is started.
+   */
+  private final DnsResolver dnsResolver;
 
   public HTTP2JettyClient(boolean http1UpgradeRequired, String name) {
     this(http1UpgradeRequired, name, null);
@@ -324,6 +331,12 @@ public class HTTP2JettyClient {
 
   public HTTP2JettyClient(boolean http1UpgradeRequired, String name,
                           HTTP2ClientProfileConfig profileConfig) {
+    this(http1UpgradeRequired, name, profileConfig, null);
+  }
+
+  public HTTP2JettyClient(boolean http1UpgradeRequired, String name,
+                          HTTP2ClientProfileConfig profileConfig, DnsResolver dnsResolver) {
+    this.dnsResolver = dnsResolver;
     loadProperties(profileConfig);
     lowLevelDebug(PLUGIN_BUILD_TAG);
 
@@ -3348,6 +3361,7 @@ public class HTTP2JettyClient {
 
   private void configureHttpClient(HttpClient client, ClientConnector connector) {
     client.setUserAgentField(null);
+    configureDnsResolution(client);
     connector.setByteBufferPool(this.bufferPool);
     client.setMaxRequestsQueuedPerDestination(maxRequestsQueuedPerDestination);
     client.setMaxConnectionsPerDestination(maxConnectionsPerDestination);
@@ -3364,6 +3378,23 @@ public class HTTP2JettyClient {
     if (LowLevelDebugLog.isEnabled()) {
       addConnectionLogging(client);
     }
+  }
+
+  /**
+   * Routes host name resolution through the plan's DNS Cache Manager, when there is one.
+   *
+   * <p>With no manager configured nothing is set and {@code HttpClient.doStart} installs its own
+   * {@code SocketAddressResolver.Async}, which is the same default {@code HTTPHC4Impl} falls back
+   * to ({@code SystemDefaultDnsResolver}). Under a proxy this still resolves the proxy host rather
+   * than the target host, because Jetty resolves {@code HttpDestination.resolveOrigin()} - again
+   * matching HC4, which connects to the proxy hop of the route.
+   */
+  private void configureDnsResolution(HttpClient client) {
+    if (dnsResolver == null) {
+      return;
+    }
+    client.setSocketAddressResolver(new JMeterDnsSocketAddressResolver(dnsResolver,
+        client::getExecutor, client::getScheduler, client.getAddressResolutionTimeout()));
   }
 
   private static void addConnectionLogging(HttpClient client) {

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -17,7 +17,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
+import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -32,11 +35,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -327,6 +332,11 @@ public class HTTP2JettyClient {
    * {@code findAuthentication} (realm/URI matching quirks) and prevents per-sample list growth.
    */
   private final Set<String> registeredAuthFingerprints = ConcurrentHashMap.newKeySet();
+  /**
+   * Every {@link ClientConnector} this client builds, so {@link #setSourceAddress} can reach the
+   * QUIC one too - no transport {@code doStart} propagates the bind address to it.
+   */
+  private final List<ClientConnector> connectors = new ArrayList<>();
   /**
    * The sampler's DNS Cache Manager, or {@code null} when the plan has none. Held so
    * {@link #configureHttpClient} can install {@link JMeterDnsSocketAddressResolver} on every
@@ -3477,8 +3487,32 @@ public class HTTP2JettyClient {
         .resolve("http2-client-alpn.log");
   }
 
+  /**
+   * Binds every outgoing connection of this client to {@code sourceAddress} (JMeter's "Source
+   * address" field, a.k.a. IP spoofing), or restores the OS default when {@code null}.
+   *
+   * <p>Must be called before {@link #start()}: Jetty reads the bind address in
+   * {@code AbstractConnectorHttpClientTransport.doStart}, which then pushes it onto the transport's
+   * own connector. The QUIC connector used for HTTP/3 is not owned by any transport's
+   * {@code doStart}, so it is set here directly - which is also why the connectors are tracked.
+   *
+   * <p>Unlike HC4 this is per client rather than per request, because that is the granularity Jetty
+   * offers. {@code HTTP2Sampler} compensates by keying its per-thread client cache on the
+   * sampler's source-address configuration, so two samplers spoofing different IPs get their own
+   * client instead of silently sharing one.
+   */
+  public void setSourceAddress(InetAddress sourceAddress) {
+    SocketAddress bindAddress =
+        sourceAddress == null ? null : new InetSocketAddress(sourceAddress, 0);
+    forEachHttpClient(client -> client.setBindAddress(bindAddress));
+    for (ClientConnector connector : connectors) {
+      connector.setBindAddress(bindAddress);
+    }
+  }
+
   private ClientConnector createClientConnector(String name) {
     ClientConnector connector = new ClientConnector();
+    connectors.add(connector);
     if (sharedThreadPoolEnabled) {
       connector.setSelectors(-1);
     } else {

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -863,6 +863,15 @@ public class HTTP2JettyClient {
     return requestTimeout;
   }
 
+  /**
+   * Whether a {@code protocol_error} may be retried over HTTP/1.1 with this client's resolved
+   * configuration. Already {@code false} whenever HTTP/1.1 is disabled, so callers do not have to
+   * pair it with a separate HTTP/1.1 check.
+   */
+  public boolean isProtocolErrorFallbackEnabled() {
+    return protocolErrorFallbackEnabled;
+  }
+
   public void loadProperties() {
     loadProperties(null);
   }
@@ -4003,11 +4012,42 @@ public class HTTP2JettyClient {
       throws URISyntaxException {
     URI uri = result.getURL().toURI();
     if ("http".equalsIgnoreCase(uri.getScheme())
-        && shouldAttachRequestBody(sampler, result, false)) {
+        && shouldAttachRequestBody(sampler, result, false)
+        && canDivertCleartextBodyToHttp11(uri)) {
       lowLevelDebug("Cleartext request with body; using HTTP/1.1-only client for {}", uri);
       return httpClientHttp1Only;
     }
     return selectHttpClient(uri, isRecoverableIfHttp3Fails(sampler));
+  }
+
+  /**
+   * Whether a bodied cleartext request may be diverted to the HTTP/1.1-only client.
+   *
+   * <p>The diversion only exists to sidestep the h2c Upgrade dance, whose first request travels as
+   * plain HTTP/1.1 and which servers handle inconsistently when it carries a body. It is a
+   * shortcut around a negotiation, never a protocol choice, so it must not fire where HTTP/1.1 is
+   * not what the configuration asks for:
+   *
+   * <ul>
+   *   <li>HTTP/1.1 disabled: no request may go out as HTTP/1.1, bodied or not. Sending one to an
+   *       h2c origin makes the server answer with HTTP/2 frames that the HTTP/1.1 parser reads as
+   *       garbage ({@code Illegal character CNTL=0x0}).</li>
+   *   <li>h2c prior knowledge (configured, or learned and still cached): the origin is spoken to
+   *       as HTTP/2 from the first byte, so there is no Upgrade to avoid in the first place.</li>
+   * </ul>
+   */
+  private boolean canDivertCleartextBodyToHttp11(URI uri) {
+    if (!enableHttp1) {
+      lowLevelDebug("Cleartext request with body but HTTP/1.1 is disabled; "
+          + "keeping protocol selection for {}", uri);
+      return false;
+    }
+    if (shouldUseH2cPriorKnowledge(uri)) {
+      lowLevelDebug("Cleartext request with body on an h2c prior-knowledge origin; "
+          + "keeping HTTP/2 for {}", uri);
+      return false;
+    }
+    return true;
   }
 
   /**

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -1913,7 +1913,7 @@ public class HTTP2JettyClient {
     lowLevelDebug("=== send() returned successfully ===");
 
     postContentResponse(sampler, request, result, contentResponse, cacheManager);
-    result.setEndTime(listener.getResponseEnd());
+    stampSampleEnd(result, listener);
 
     resetSamplerDataBeforeResultProcessing(result);
     return sampler.resultProcessing(areFollowingRedirect, depth, result);
@@ -1968,6 +1968,27 @@ public class HTTP2JettyClient {
     return sampler.resultProcessing(areFollowingRedirect, depth, result);
   }
 
+  /**
+   * Ends the sample when the exchange ended, translated onto this result's own clock: the start
+   * came from {@code sampleStart()}, and a {@link org.apache.jmeter.samplers.SampleResult} keeps a
+   * nano-derived clock of its own by default, so reading the end straight off the listener's
+   * wall-clock stamp reported the distance between the two clocks as part of the sample's duration.
+   * See {@link SampleClock}.
+   *
+   * <p>Falls back to {@code sampleEnd()} when the exchange never recorded a completion. Stamping
+   * what the listener held in that case wrote a 0, and {@code setEndTime} turns a zero end into an
+   * elapsed time of minus the start of the epoch.
+   */
+  private static void stampSampleEnd(HTTPSampleResult result,
+                                     HTTP2FutureResponseListener listener) {
+    long endTime = listener.getResponseEndOn(result);
+    if (endTime > 0) {
+      result.setEndTime(endTime);
+    } else if (result.getEndTime() == 0) {
+      result.sampleEnd();
+    }
+  }
+
   public HTTPSampleResult sampleFromListener(HTTP2Sampler sampler, HTTPSampleResult result,
                                              boolean areFollowingRedirect, int depth,
                                              HTTP2FutureResponseListener listener
@@ -1981,7 +2002,7 @@ public class HTTP2JettyClient {
       JettyCacheManager cacheManager =
           JettyCacheManager.fromCacheManager(sampler.getCacheManager());
       postContentResponse(sampler, request, result, contentResponse, cacheManager);
-      result.setEndTime(listener.getResponseEnd());
+      stampSampleEnd(result, listener);
 
       resetSamplerDataBeforeResultProcessing(result);
       return sampler.resultProcessing(areFollowingRedirect, depth, result);
@@ -2008,7 +2029,11 @@ public class HTTP2JettyClient {
           JettyCacheManager cacheManager =
               JettyCacheManager.fromCacheManager(sampler.getCacheManager());
           postContentResponse(sampler, request, result, retryResponse, cacheManager);
-          result.setEndTime(listener.getResponseEnd());
+          // Not from the listener: the only completion it ever recorded is the GOAWAY that killed
+          // the first attempt. retryAfterGoAway sends a clone of its own and returns the response
+          // it got, so the sample ends now - stamping the listener's end reported a sample that
+          // finished before the response it carries, missing the whole retry.
+          result.setEndTime(result.currentTimeInMillis());
           resetSamplerDataBeforeResultProcessing(result);
           return sampler.resultProcessing(areFollowingRedirect, depth, result);
         } catch (Exception retryException) {
@@ -2334,8 +2359,7 @@ public class HTTP2JettyClient {
             h2Request.abort(new java.util.concurrent.CancellationException(
                 "Happy Eyeballs H3 won"));
           } else {
-            h3Listener.completeWith(response,
-                h2Listener.getResponseStart(), h2Listener.getResponseEnd());
+            h3Listener.completeWith(response, h2Listener);
             h3Request.abort(new java.util.concurrent.CancellationException(
                 "Happy Eyeballs H2 won"));
           }

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -333,6 +333,12 @@ public class HTTP2JettyClient {
    */
   private final Set<String> registeredAuthFingerprints = ConcurrentHashMap.newKeySet();
   /**
+   * Recovers the per-address connection failures Jetty discards while walking the resolved
+   * addresses. Shared by every connector this client builds, so an attempt is captured whichever
+   * protocol variant made it.
+   */
+  private final ConnectAttemptRecorder connectAttempts = new ConnectAttemptRecorder();
+  /**
    * Every {@link ClientConnector} this client builds, so {@link #setSourceAddress} can reach the
    * QUIC one too - no transport {@code doStart} propagates the bind address to it.
    */
@@ -600,7 +606,8 @@ public class HTTP2JettyClient {
     // even though ALPN negotiates HTTP/2 successfully. This is a regression from Jetty 11.
     // We try HTTP/2 first, then fallback to HTTP/1.1 if needed.
     ClientConnectionFactory.Info[] mainProtocols = buildMainProtocols(http3, http2, http11);
-    HttpClientTransport transport = new HttpClientTransportDynamic(clientConnector, mainProtocols);
+    HttpClientTransport transport =
+        new RecordingHttpClientTransportDynamic(clientConnector, mainProtocols);
     mainProtocolsSnapshot = protocolList(mainProtocols);
     lowLevelDebug("HttpClientTransportDynamic configured with protocols: {}",
         mainProtocolsSnapshot);
@@ -617,13 +624,14 @@ public class HTTP2JettyClient {
       ClientConnector noH3Connector = createClientConnector(name + "-noh3");
       ClientConnectionFactory.Info[] noH3Protocols = buildNoH3Protocols(http2, http11);
       HttpClientTransport noH3Transport =
-          new HttpClientTransportDynamic(noH3Connector, noH3Protocols);
+          new RecordingHttpClientTransportDynamic(noH3Connector, noH3Protocols);
       configureTransport(noH3Transport);
       this.httpClientNoH3 = new HttpClient(noH3Transport);
       configureHttpClient(this.httpClientNoH3, noH3Connector);
     }
     ClientConnector http1Connector = createClientConnector(name + "-http1");
-    HttpClientTransport http1Transport = new HttpClientTransportDynamic(http1Connector, http11);
+    HttpClientTransport http1Transport =
+        new RecordingHttpClientTransportDynamic(http1Connector, http11);
     // HTTP/1.1 has no multiplexing (Jetty rejects a 2nd in-flight exchange per connection).
     configureTransport(http1Transport, 1);
     this.httpClientHttp1Only = new HttpClient(http1Transport);
@@ -643,7 +651,7 @@ public class HTTP2JettyClient {
     ClientConnectionFactory.Info[] h2cUpgradeProtocols =
         buildH2cUpgradeProtocols(http11, http2cUpgrade);
     HttpClientTransport h2cUpgradeTransport =
-        new HttpClientTransportDynamic(h2cUpgradeConnector, h2cUpgradeProtocols);
+        new RecordingHttpClientTransportDynamic(h2cUpgradeConnector, h2cUpgradeProtocols);
     configureTransport(h2cUpgradeTransport);
     this.httpClientH2cUpgrade = new HttpClient(h2cUpgradeTransport);
     configureHttpClient(this.httpClientH2cUpgrade, h2cUpgradeConnector);
@@ -657,7 +665,8 @@ public class HTTP2JettyClient {
     } else {
       http2cClient.setMaxConcurrentPushedStreams(maxConcurrentPushedStreams);
     }
-    HttpClientTransport h2cTransport = new CustomHttpClientTransportOverHTTP2(http2cClient);
+    HttpClientTransport h2cTransport =
+        new CustomHttpClientTransportOverHTTP2(http2cClient, connectAttempts);
     configureTransport(h2cTransport);
     this.httpClientH2cPrior = new HttpClient(h2cTransport);
     configureHttpClient(this.httpClientH2cPrior, h2cConnector);
@@ -1260,7 +1269,8 @@ public class HTTP2JettyClient {
 
     // Create transport with ONLY HTTP/1.1 (no HTTP/2)
     ClientConnectionFactory.Info http11 = HttpClientConnectionFactory.HTTP11;
-    HttpClientTransport transport = new HttpClientTransportDynamic(clientConnector, http11);
+    HttpClientTransport transport =
+        new RecordingHttpClientTransportDynamic(clientConnector, http11);
     lowLevelDebug("HttpClientTransportDynamic configured with HTTP/1.1 only (fallback mode)");
 
     HttpClient http11Client = new HttpClient(transport);
@@ -3362,6 +3372,28 @@ public class HTTP2JettyClient {
     return request;
   }
 
+  /**
+   * {@link HttpClientTransportDynamic} that lets {@link ConnectAttemptRecorder} see the failure of
+   * each resolved address before Jetty silently moves on to the next one.
+   *
+   * <p>This is the one point where the address being attempted and the promise that decides the
+   * roll-over are both in hand, which is why it covers a refused socket, a TLS handshake and the
+   * HTTP/2 preface alike.
+   */
+  private class RecordingHttpClientTransportDynamic extends HttpClientTransportDynamic {
+
+    RecordingHttpClientTransportDynamic(ClientConnector connector,
+                                        ClientConnectionFactory.Info... infos) {
+      super(connector, infos);
+    }
+
+    @Override
+    public void connect(SocketAddress address, Map<String, Object> context) {
+      connectAttempts.instrument(address, context);
+      super.connect(address, context);
+    }
+  }
+
   private static class HappyEyeballsThreadFactory implements ThreadFactory {
     private final String prefix;
     private final AtomicInteger counter = new AtomicInteger(1);
@@ -3508,6 +3540,14 @@ public class HTTP2JettyClient {
     for (ClientConnector connector : connectors) {
       connector.setBindAddress(bindAddress);
     }
+  }
+
+  /**
+   * Attaches every connection failure recorded for {@code url} since {@code sinceMillis} to
+   * {@code failure} as suppressed exceptions, recovering the attempts Jetty discarded.
+   */
+  public void attachConnectAttempts(Throwable failure, URL url, long sinceMillis) {
+    connectAttempts.attachTo(failure, url, sinceMillis);
   }
 
   private ClientConnector createClientConnector(String name) {
@@ -5073,4 +5113,3 @@ public class HTTP2JettyClient {
     }
   }
 }
-

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -184,6 +184,15 @@ public class HTTP2JettyClient {
   private static final String ATTR_SKIP_H2C_UPGRADE = "bzm.skipH2cUpgrade";
   private static final String ATTR_ORIGIN_KEY = "bzm.http3.origin";
   private static final String ATTR_REQUEST_HEADERS_SERIALIZED = "bzm.request.headers.serialized";
+  /**
+   * JMeter's deprecated "BASIC_DIGEST" Auth Manager mechanism, still selectable in the GUI and
+   * still present in older plans. HC4 keeps honouring it: {@code AuthManager.setupCredentials}
+   * registers the credentials without binding them to a scheme, so they answer either challenge,
+   * and the preemptive auth cache treats the row as Basic. Referenced by name so this file does
+   * not have to carry a deprecation suppression, the same way the surrounding code compares
+   * mechanisms by {@code name()}.
+   */
+  private static final String BASIC_DIGEST_MECHANISM = "BASIC_DIGEST";
   private static final String PROP_SKIP_REDUNDANT_MANUAL_DECODE =
       "blazemeter.http.skipManualDecodeWhenAdvertised";
   private static final Path DEBUG_LOG_PATH = resolveDebugLogPath();
@@ -3679,24 +3688,44 @@ public class HTTP2JettyClient {
   private boolean isSupportedMechanism(Authorization auth) {
     String authName = auth.getMechanism().name();
     return authName.equals(AuthManager.Mechanism.BASIC.name())
-        || authName.equals(AuthManager.Mechanism.DIGEST.name());
+        || authName.equals(AuthManager.Mechanism.DIGEST.name())
+        || authName.equals(BASIC_DIGEST_MECHANISM);
+  }
+
+  /**
+   * Whether the row may answer a {@code Basic} challenge, which {@code BASIC_DIGEST} rows may.
+   */
+  private static boolean answersBasicChallenge(Authorization auth) {
+    String authName = auth.getMechanism().name();
+    return authName.equals(AuthManager.Mechanism.BASIC.name())
+        || authName.equals(BASIC_DIGEST_MECHANISM);
+  }
+
+  /**
+   * Whether the row may answer a {@code Digest} challenge, which {@code BASIC_DIGEST} rows may.
+   */
+  private static boolean answersDigestChallenge(Authorization auth) {
+    String authName = auth.getMechanism().name();
+    return authName.equals(AuthManager.Mechanism.DIGEST.name())
+        || authName.equals(BASIC_DIGEST_MECHANISM);
   }
 
   private void addAuthenticationToJettyClient(Authorization auth) {
     String authName = auth.getMechanism().name();
-    if (authName.equals(AuthManager.Mechanism.BASIC.name())
-        && BzmHttpPluginProperties.getPropDefault("httpJettyClient.auth.preemptive", false)) {
+    boolean preemptive =
+        BzmHttpPluginProperties.getPropDefault("httpJettyClient.auth.preemptive", false);
+    if (preemptive && answersBasicChallenge(auth)) {
       BasicAuthentication.BasicResult result =
           new BasicAuthentication.BasicResult(URI.create(auth.getURL()), auth.getUser(),
               auth.getPass());
       // Results are keyed by URI (Map.put replaces); safe to re-register every sample.
       forEachAuthenticationStore(store -> store.addAuthenticationResult(result));
-      return;
-    }
-
-    String fingerprint = authFingerprint(auth);
-    if (!registeredAuthFingerprints.add(fingerprint)) {
-      return;
+      if (authName.equals(AuthManager.Mechanism.BASIC.name())) {
+        return;
+      }
+      // A BASIC_DIGEST row falls through: sending Basic up front is what HC4's auth cache does,
+      // but the credentials must still be able to answer whichever challenge the server sends
+      // back, which is the whole point of the mechanism.
     }
 
     URI uri = URI.create(auth.getURL());
@@ -3705,10 +3734,26 @@ public class HTTP2JettyClient {
       // Blank JMeter realm must match any challenge realm; "" would only match "".
       realm = Authentication.ANY_REALM;
     }
-    AbstractAuthentication authentication =
-        authName.equals(AuthManager.Mechanism.BASIC.name())
-            ? new BasicAuthentication(uri, realm, auth.getUser(), auth.getPass())
-            : new DigestAuthentication(uri, realm, auth.getUser(), auth.getPass());
+    if (answersBasicChallenge(auth)) {
+      registerAuthentication(auth,
+          new BasicAuthentication(uri, realm, auth.getUser(), auth.getPass()));
+    }
+    if (answersDigestChallenge(auth)) {
+      registerAuthentication(auth,
+          new DigestAuthentication(uri, realm, auth.getUser(), auth.getPass()));
+    }
+  }
+
+  /**
+   * Adds one Jetty authentication to every protocol-variant store, once per distinct row.
+   *
+   * <p>The fingerprint carries the Jetty authentication type because a single {@code BASIC_DIGEST}
+   * row produces two of them, and both have to get through.
+   */
+  private void registerAuthentication(Authorization auth, AbstractAuthentication authentication) {
+    if (!registeredAuthFingerprints.add(authFingerprint(auth) + '|' + authentication.getType())) {
+      return;
+    }
     forEachAuthenticationStore(store -> store.addAuthentication(authentication));
   }
 
@@ -4031,7 +4076,7 @@ public class HTTP2JettyClient {
     StreamSupport.stream(authManager.getAuthObjects().spliterator(), false)
         .map(j -> (Authorization) j.getObjectValue())
         .filter(auth -> auth != null
-            && AuthManager.Mechanism.BASIC.equals(auth.getMechanism())
+            && answersBasicChallenge(auth)
             && !StringUtils.isEmpty(auth.getURL()))
         .filter(auth -> url.toString().startsWith(auth.getURL()))
         .findFirst()

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -189,6 +189,17 @@ public class HTTP2JettyClient {
   private static final String ATTR_HTTP3_ATTEMPTED = "bzm.http3.attempted";
   private static final String ATTR_H2C_FALLBACK_ATTEMPTED = "bzm.h2cFallbackAttempted";
   private static final String ATTR_SKIP_H2C_UPGRADE = "bzm.skipH2cUpgrade";
+  /**
+   * Statuses that answer an {@code Upgrade: h2c} attempt by refusing it rather than by serving the
+   * request: a bad request, an upgrade demanded or not implemented, a version not supported. Only
+   * these are worth sending again without the upgrade headers - see
+   * {@link #shouldRetryAfterFailedH2cUpgrade}.
+   */
+  private static final Set<Integer> H2C_UPGRADE_REFUSED_STATUSES = Set.of(
+      HttpStatus.BAD_REQUEST_400,
+      HttpStatus.UPGRADE_REQUIRED_426,
+      HttpStatus.NOT_IMPLEMENTED_501,
+      HttpStatus.HTTP_VERSION_NOT_SUPPORTED_505);
   private static final String ATTR_ORIGIN_KEY = "bzm.http3.origin";
   private static final String ATTR_REQUEST_HEADERS_SERIALIZED = "bzm.request.headers.serialized";
   /**
@@ -1450,9 +1461,20 @@ public class HTTP2JettyClient {
   }
 
   /**
-   * The server answered (no timeout/error) but never actually negotiated HTTP/2 despite our
-   * {@code Upgrade: h2c} attempt - e.g. it silently ignored the header, as a compliant HTTP/1.1
-   * server that doesn't support h2c is allowed to do. Retry once with a plain HTTP/1.1 request.
+   * Whether the {@code Upgrade: h2c} attempt has to be made again as a plain HTTP/1.1 request.
+   *
+   * <p>Only when the answer says the upgrade attempt itself was refused. A compliant HTTP/1.1
+   * server that does not speak h2c ignores the header and serves the request over HTTP/1.1, and
+   * that response <em>is</em> the answer to this request: re-sending it would put the same request
+   * on the wire twice - twice the load, and twice the side effect for anything that is not a GET -
+   * and would report only the second attempt's time. What is left of the failed negotiation is
+   * remembered by {@link #updateHttp1OnlyCache}, so the requests after it skip the upgrade instead
+   * of paying for it again.
+   *
+   * <p>A server or proxy that answers the upgrade headers with one of
+   * {@link #H2C_UPGRADE_REFUSED_STATUSES} did not serve the request, it rejected the attempt, and
+   * that is a failure this client caused by adding headers the test plan never asked for. Those are
+   * retried once, without the headers.
    */
   private boolean shouldRetryAfterFailedH2cUpgrade(Request request, ContentResponse response) {
     if (!enableHttp1 || !http1UpgradeRequired || request == null || response == null) {
@@ -1469,7 +1491,8 @@ public class HTTP2JettyClient {
     if (!wasH2cUpgradeAttempt(request)) {
       return false;
     }
-    return response.getVersion() != HttpVersion.HTTP_2;
+    return response.getVersion() != HttpVersion.HTTP_2
+        && H2C_UPGRADE_REFUSED_STATUSES.contains(response.getStatus());
   }
 
   private void markCleartextHttp1Only(URI uri) {
@@ -4196,8 +4219,14 @@ public class HTTP2JettyClient {
     // 1. The connection is already HTTP/2 (negotiated via ALPN)
     // 2. Upgrade headers are for cleartext HTTP, not HTTPS
     // 3. It violates the HTTP/2 protocol (RFC 7540)
+    // An origin already known to answer HTTP/1.1 is not asked to upgrade again: the attempt costs
+    // three headers and Jetty's upgrade machinery on every request, and the negotiation it asks for
+    // is one this client already watched fail. This is the "later requests skip the futile upgrade
+    // attempt" the HTTP/1.1-only cache is written for - until now the cache only steered which
+    // client was used, and the headers went out regardless.
     if (http1UpgradeRequired && enableHttp2 && !"https".equalsIgnoreCase(url.getProtocol())
         && !shouldUseH2cPriorKnowledge(request.getURI())
+        && !isHttp1Only(request.getURI())
         && !Boolean.TRUE.equals(request.getAttributes().get(ATTR_SKIP_H2C_UPGRADE))) {
       Mutable headers = ((Mutable) request.getHeaders());
       addHeaderIfMissing(HttpHeader.UPGRADE, "h2c", headers);

--- a/src/main/java/com/blazemeter/jmeter/http2/core/JMeterDnsSocketAddressResolver.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/JMeterDnsSocketAddressResolver.java
@@ -1,0 +1,136 @@
+package com.blazemeter.jmeter.http2.core;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import org.apache.http.conn.DnsResolver;
+import org.eclipse.jetty.util.Promise;
+import org.eclipse.jetty.util.SocketAddressResolver;
+import org.eclipse.jetty.util.thread.Scheduler;
+
+/**
+ * Resolves host names through JMeter's DNS Cache Manager instead of {@code InetAddress}, so a test
+ * plan's custom DNS servers, static host entries and per-thread DNS cache apply to this plugin
+ * exactly as they do to {@code HTTPHC4Impl}.
+ *
+ * <p>{@code DNSCacheManager} is an {@code org.apache.http.conn.DnsResolver}, which is what
+ * {@code HTTPHC4Impl} hands to its connection operator on the one-time client init. This class is
+ * the Jetty-side equivalent: {@code HttpClient} resolves through a {@link SocketAddressResolver},
+ * and installing one is enough to cover every protocol, because HTTP/1.1, h2, h2c and HTTP/3 all
+ * reach the network through {@code HttpClient.newConnection}.
+ *
+ * <p>Deliberately modelled on {@link SocketAddressResolver.Async}, which it replaces: the lookup
+ * runs on the client executor rather than on the caller (which may be a selector thread), and a
+ * scheduled task fails the promise if the lookup outlives the timeout. The guard is not optional
+ * here - JMeter never calls {@code DNSCacheManager.setTimeoutMs}, so a custom resolver inherits
+ * dnsjava's own retry behaviour and a black-holed DNS server would otherwise pin an executor
+ * thread with nothing failing the request.
+ *
+ * <p>The executor and scheduler are read lazily because the resolver is installed while the
+ * {@code HttpClient} is still being built: {@code HttpClient.doStart} only creates its default
+ * {@code Async} resolver when none was set, so ours has to be in place before {@code start()},
+ * at which point {@code getExecutor()} and {@code getScheduler()} are still {@code null}.
+ */
+public class JMeterDnsSocketAddressResolver implements SocketAddressResolver {
+
+  private final DnsResolver dnsResolver;
+  private final Supplier<Executor> executorSupplier;
+  private final Supplier<Scheduler> schedulerSupplier;
+  private final long timeoutMs;
+
+  public JMeterDnsSocketAddressResolver(DnsResolver dnsResolver,
+                                        Supplier<Executor> executorSupplier,
+                                        Supplier<Scheduler> schedulerSupplier,
+                                        long timeoutMs) {
+    this.dnsResolver = dnsResolver;
+    this.executorSupplier = executorSupplier;
+    this.schedulerSupplier = schedulerSupplier;
+    this.timeoutMs = timeoutMs;
+  }
+
+  @Override
+  public void resolve(String host, int port, Map<String, Object> context,
+                      Promise<List<InetSocketAddress>> promise) {
+    Executor executor = executorSupplier.get();
+    if (executor == null) {
+      // Only reachable if a caller resolves before the client is started; resolving inline is
+      // still better than dropping the request on the floor.
+      resolveAndComplete(host, port, promise, new AtomicBoolean());
+      return;
+    }
+    executor.execute(() -> {
+      AtomicBoolean complete = new AtomicBoolean();
+      Scheduler.Task timeoutTask = scheduleTimeout(host, Thread.currentThread(), complete, promise);
+      try {
+        resolveAndComplete(host, port, promise, complete);
+      } finally {
+        if (timeoutTask != null) {
+          timeoutTask.cancel();
+        }
+        // The timeout task interrupts this thread to unblock the lookup; clear the flag so the
+        // pooled thread does not carry it into unrelated work.
+        Thread.interrupted();
+      }
+    });
+  }
+
+  private Scheduler.Task scheduleTimeout(String host, Thread resolvingThread,
+                                         AtomicBoolean complete,
+                                         Promise<List<InetSocketAddress>> promise) {
+    Scheduler scheduler = schedulerSupplier.get();
+    if (timeoutMs <= 0 || scheduler == null) {
+      return null;
+    }
+    return scheduler.schedule(() -> {
+      if (complete.compareAndSet(false, true)) {
+        promise.failed(new TimeoutException(
+            "DNS timeout " + timeoutMs + " ms resolving " + host));
+        resolvingThread.interrupt();
+      }
+    }, timeoutMs, TimeUnit.MILLISECONDS);
+  }
+
+  private void resolveAndComplete(String host, int port,
+                                  Promise<List<InetSocketAddress>> promise,
+                                  AtomicBoolean complete) {
+    try {
+      InetAddress[] addresses = resolveAddresses(host);
+      // DNSCacheManager returns null when a custom lookup cannot parse the name, and an empty
+      // array when a static host entry is matched case-insensitively by isStaticHost but read
+      // case-sensitively by fromStaticHost (a JMeter bug still present on master). Neither may
+      // reach Jetty as a success: HttpClient indexes straight into the returned list.
+      if (addresses == null || addresses.length == 0) {
+        throw new UnknownHostException(host);
+      }
+      List<InetSocketAddress> result = new ArrayList<>(addresses.length);
+      for (InetAddress address : addresses) {
+        result.add(new InetSocketAddress(address, port));
+      }
+      if (complete.compareAndSet(false, true)) {
+        promise.succeeded(result);
+      }
+    } catch (Throwable failure) {
+      if (complete.compareAndSet(false, true)) {
+        promise.failed(failure);
+      }
+    }
+  }
+
+  private InetAddress[] resolveAddresses(String host) throws UnknownHostException {
+    // DNSCacheManager keeps its cache in a plain LinkedHashMap and JMeter clones one instance per
+    // thread, but a single JMeter thread resolves concurrently here (embedded resources, and the
+    // HTTP/3 vs HTTP/2 race, run on plugin executors). Serializing keeps that map consistent;
+    // cache hits make the critical section negligible.
+    synchronized (dnsResolver) {
+      return dnsResolver.resolve(host);
+    }
+  }
+}

--- a/src/main/java/com/blazemeter/jmeter/http2/core/JMeterSourceAddressResolver.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/JMeterSourceAddressResolver.java
@@ -1,0 +1,146 @@
+package com.blazemeter.jmeter.http2.core;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase;
+import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase.SourceType;
+import org.apache.jmeter.util.JMeterUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resolves the local address a sample must go out from - JMeter's "Source address" field, also
+ * known as IP spoofing.
+ *
+ * <p>Port of {@code HTTPAbstractImpl.getIpSourceAddress()} plus the {@code httpclient.localaddress}
+ * fallback that {@code HTTPHCAbstractImpl} reads. It has to be a port rather than a delegation
+ * because that method is {@code protected} on the {@code HTTPAbstractImpl} hierarchy, which
+ * {@code HTTP2Sampler} does not extend - it extends {@link HTTPSamplerBase} directly.
+ *
+ * <p>Precedence matches {@code HTTPHC4Impl.setupRequest}: the sampler's own field wins, the global
+ * property is the fallback, and neither one means the OS picks the interface.
+ */
+public final class JMeterSourceAddressResolver {
+
+  private static final String LOCAL_ADDRESS_PROPERTY = "httpclient.localaddress";
+
+  private static final Logger LOG = LoggerFactory.getLogger(JMeterSourceAddressResolver.class);
+
+  private JMeterSourceAddressResolver() {
+  }
+
+  /**
+   * Returns the local address for {@code sampler}, or {@code null} to let the OS choose.
+   *
+   * @param sampler the sampler whose "Source address" field and type are read; its properties are
+   *     already variable-expanded by the time a sample runs, so the value may differ per iteration
+   * @return the address to bind outgoing connections to, or {@code null} when none applies
+   * @throws UnknownHostException if the configured host name, IP or interface cannot be resolved,
+   *     which is what HC4 propagates out of {@code setupRequest} to fail the sample
+   * @throws SocketException if the interface list cannot be read
+   */
+  public static InetAddress resolve(HTTPSamplerBase sampler)
+      throws UnknownHostException, SocketException {
+    InetAddress fromSampler = resolveIpSource(sampler.getIpSource(), sampler.getIpSourceType());
+    return fromSampler != null ? fromSampler : resolveLocalAddressProperty();
+  }
+
+  /**
+   * Identifies the source-address configuration a client would be built with, for use in a client
+   * cache key. Empty when no source address applies.
+   *
+   * <p>Mirrors the precedence in {@link #resolve} without resolving anything, so it stays off the
+   * per-sample path: resolving a device name walks the interface list.
+   *
+   * <p>{@code httpclient.localaddress} is included even though it is global and normally constant.
+   * Every sampler that falls back to it binds to the same address, so sharing one client is the
+   * right outcome and keying on it changes nothing in a normal run - but a plan can change a
+   * JMeter property at runtime, and a cached client keeps the address it was built with. Reading
+   * the raw value costs a property lookup and removes the assumption that it never moves.
+   */
+  public static String cacheKeyFor(HTTPSamplerBase sampler) {
+    String ipSource = sampler.getIpSource();
+    if (ipSource != null && !ipSource.trim().isEmpty()) {
+      return ipSource.trim() + "/" + sampler.getIpSourceType();
+    }
+    String localAddress = JMeterUtils.getPropDefault(LOCAL_ADDRESS_PROPERTY, "").trim();
+    // Prefixed so a property value can never collide with a sampler field of the same text.
+    return localAddress.isEmpty() ? "" : "@" + localAddress;
+  }
+
+  /**
+   * Whether {@code sampler} asks for any source address at all, without resolving it.
+   *
+   * <p>Lets callers keep an unconfigured plan on the cheap path: no interface enumeration, and no
+   * failure from a global property that a sampler-level field would have overridden anyway.
+   */
+  public static boolean isConfigured(HTTPSamplerBase sampler) {
+    String ipSource = sampler.getIpSource();
+    return (ipSource != null && !ipSource.trim().isEmpty())
+        || !JMeterUtils.getPropDefault(LOCAL_ADDRESS_PROPERTY, "").isEmpty();
+  }
+
+  private static InetAddress resolveIpSource(String ipSource, int ipSourceType)
+      throws UnknownHostException, SocketException {
+    if (ipSource == null || ipSource.trim().isEmpty()) {
+      return null; // did not want to spoof the IP address
+    }
+    Class<? extends InetAddress> ipClass;
+    switch (SourceType.values()[ipSourceType]) {
+      case DEVICE:
+        ipClass = InetAddress.class;
+        break;
+      case DEVICE_IPV4:
+        ipClass = Inet4Address.class;
+        break;
+      case DEVICE_IPV6:
+        ipClass = Inet6Address.class;
+        break;
+      case HOSTNAME:
+      default:
+        return InetAddress.getByName(ipSource);
+    }
+    return firstInterfaceAddress(ipSource, ipClass);
+  }
+
+  private static InetAddress firstInterfaceAddress(String device,
+                                                   Class<? extends InetAddress> ipClass)
+      throws UnknownHostException, SocketException {
+    NetworkInterface net = NetworkInterface.getByName(device);
+    if (net == null) {
+      throw new UnknownHostException("Cannot find interface " + device);
+    }
+    for (InterfaceAddress interfaceAddress : net.getInterfaceAddresses()) {
+      InetAddress address = interfaceAddress.getAddress();
+      if (ipClass.isInstance(address)) {
+        return address;
+      }
+    }
+    throw new UnknownHostException("Interface " + device
+        + " does not have address of type " + ipClass.getSimpleName());
+  }
+
+  /**
+   * HC4 logs a warning and carries on when this property does not resolve, so a typo degrades to
+   * "let the OS choose" instead of breaking every sample in the plan. Only a sampler-level field
+   * is allowed to fail a sample.
+   */
+  private static InetAddress resolveLocalAddressProperty() {
+    String localHostOrIp = JMeterUtils.getPropDefault(LOCAL_ADDRESS_PROPERTY, "");
+    if (localHostOrIp.isEmpty()) {
+      return null;
+    }
+    try {
+      return InetAddress.getByName(localHostOrIp);
+    } catch (UnknownHostException e) {
+      LOG.warn("Ignoring {}={}: {}", LOCAL_ADDRESS_PROPERTY, localHostOrIp,
+          e.getLocalizedMessage());
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/blazemeter/jmeter/http2/core/JMeterSourceAddressResolver.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/JMeterSourceAddressResolver.java
@@ -82,7 +82,7 @@ public final class JMeterSourceAddressResolver {
   public static boolean isConfigured(HTTPSamplerBase sampler) {
     String ipSource = sampler.getIpSource();
     return (ipSource != null && !ipSource.trim().isEmpty())
-        || !JMeterUtils.getPropDefault(LOCAL_ADDRESS_PROPERTY, "").isEmpty();
+        || !JMeterUtils.getPropDefault(LOCAL_ADDRESS_PROPERTY, "").trim().isEmpty();
   }
 
   private static InetAddress resolveIpSource(String ipSource, int ipSourceType)
@@ -131,7 +131,7 @@ public final class JMeterSourceAddressResolver {
    * is allowed to fail a sample.
    */
   private static InetAddress resolveLocalAddressProperty() {
-    String localHostOrIp = JMeterUtils.getPropDefault(LOCAL_ADDRESS_PROPERTY, "");
+    String localHostOrIp = JMeterUtils.getPropDefault(LOCAL_ADDRESS_PROPERTY, "").trim();
     if (localHostOrIp.isEmpty()) {
       return null;
     }

--- a/src/main/java/com/blazemeter/jmeter/http2/core/JmeterRequestHeadersSupport.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/JmeterRequestHeadersSupport.java
@@ -110,17 +110,50 @@ final class JmeterRequestHeadersSupport {
     return "BlazeMeter HTTP/" + version;
   }
 
+  /**
+   * Reports the {@code Connection} header the sampler asked for, the way {@code HTTPHC4Impl} does,
+   * even when this client owns that header on the wire for its own reasons.
+   *
+   * <p>An {@code h2c} upgrade attempt has to send {@code Connection: Upgrade, HTTP2-Settings} for
+   * the upgrade to be well formed, and only some requests carry it - the ones that probe a
+   * cleartext origin for HTTP/2. Leaving the sample with just those tokens made the keep-alive the
+   * sampler asked for disappear from exactly those requests, so a plan asserting
+   * {@code Connection: keep-alive} on its request headers failed on the one request that happened
+   * to probe. The upgrade tokens stay in the reported header, with the sampler's own token in front
+   * of them.
+   *
+   * <p>A {@code Connection} header that came from the test plan is left exactly as the plan wrote
+   * it, and an HTTP/2 request gets none at all.
+   */
   private static void restoreConnectionHeaderForSample(
       Request request, HttpFields.Mutable headers) {
     Object useKeepAlive = request.getAttributes().get(ATTR_USE_KEEPALIVE);
-    if (useKeepAlive == null || !shouldSendConnectionHeader(request)) {
+    if (useKeepAlive == null || request.getVersion() == HttpVersion.HTTP_2) {
       return;
     }
-    if (Boolean.TRUE.equals(useKeepAlive)) {
-      headers.put(HTTPConstants.HEADER_CONNECTION, HTTPConstants.KEEP_ALIVE);
-    } else {
-      headers.put(HTTPConstants.HEADER_CONNECTION, HTTPConstants.CONNECTION_CLOSE);
+    String samplerToken = Boolean.TRUE.equals(useKeepAlive)
+        ? HTTPConstants.KEEP_ALIVE
+        : HTTPConstants.CONNECTION_CLOSE;
+    HttpFields onTheWire = request.getHeaders();
+    String connection = onTheWire == null ? null : onTheWire.get(HttpHeader.CONNECTION);
+    if (connection == null) {
+      headers.put(HTTPConstants.HEADER_CONNECTION, samplerToken);
+      return;
     }
+    if (!containsToken(connection, HttpHeader.UPGRADE.asString())
+        || containsToken(connection, samplerToken)) {
+      return;
+    }
+    headers.put(HTTPConstants.HEADER_CONNECTION, samplerToken + ", " + connection);
+  }
+
+  private static boolean containsToken(String headerValue, String token) {
+    for (String candidate : headerValue.split(",")) {
+      if (candidate.trim().equalsIgnoreCase(token)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static boolean shouldSendConnectionHeader(Request request) {

--- a/src/main/java/com/blazemeter/jmeter/http2/core/SampleClock.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/SampleClock.java
@@ -1,0 +1,105 @@
+package com.blazemeter.jmeter.http2.core;
+
+import org.apache.jmeter.samplers.SampleResult;
+
+/**
+ * Puts a time taken by the Jetty transport on the clock the {@link SampleResult} it is about to be
+ * stamped on keeps its own times in, and stamps an interval that was measured elsewhere.
+ *
+ * <p>A {@code SampleResult} does not read {@link System#currentTimeMillis()} when
+ * {@code sampleresult.useNanoTime} is on, which is JMeter's shipped default: every stamp of its own
+ * comes from {@code System.nanoTime() / 1_000_000} plus an offset the instance captures once, at
+ * construction, from a value a daemon refreshes every {@code sampleresult.nanoThreadSleep} ms (5 s
+ * by default). A wall-clock reading and a {@code SampleResult}-clock reading of the same instant
+ * therefore differ by however stale that offset is, and {@link SampleResult#setEndTime} turns the
+ * difference straight into reported sample time, since it computes
+ * {@code elapsed = end - start - idle}. Taking a sample's start from {@code sampleStart()} and its
+ * end from the wall clock is not a rounding error, it is a measurement across two clocks - which is
+ * why JMeter's own HTTP samplers only ever stamp through {@code sampleEnd()},
+ * {@code latencyEnd()} and {@code connectEnd()}.
+ *
+ * <p>Every conversion here is expressed as "how far is that clock from this result's clock right
+ * now", which is exact when {@code useNanoTime} is off - both clocks are then the same one - and
+ * within the 1 ms resolution of the offset when it is on.
+ */
+public final class SampleClock {
+
+  /**
+   * Whether {@link SampleResult#setStampAndTime(long, long)} reads its first argument as the start
+   * of the sample. It reads it as the end when {@code sampleresult.timestamp.start} is off, and
+   * JMeter's shipped {@code jmeter.properties} turns it on while the property's built-in default is
+   * off - so which one a run uses cannot be assumed either way. Measured from the behaviour itself
+   * rather than read from the property, so this agrees with whatever {@code SampleResult} settled
+   * on when its own class was initialised.
+   */
+  private static final boolean STAMP_IS_START = probeStampIsStart();
+
+  private SampleClock() {
+  }
+
+  /**
+   * Converts a {@link System#nanoTime()} reading into {@code result}'s clock.
+   *
+   * <p>Preferred over {@link #fromWallClock}: a monotonic reading cannot be displaced by an NTP
+   * step, or by an operator moving the machine clock, between the moment it was taken and the
+   * moment the sample is stamped.
+   */
+  public static long fromNanoTime(SampleResult result, long nanoTime) {
+    return nanoClockMillis(nanoTime)
+        + (result.currentTimeInMillis() - nanoClockMillis(System.nanoTime()));
+  }
+
+  /**
+   * Converts a {@link System#currentTimeMillis()} reading into {@code result}'s clock. For instants
+   * no monotonic reading was taken for.
+   */
+  public static long fromWallClock(SampleResult result, long wallClockMillis) {
+    return wallClockMillis + (result.currentTimeInMillis() - System.currentTimeMillis());
+  }
+
+  /**
+   * Converts a time on {@code result}'s clock back to {@link System#currentTimeMillis()}, for
+   * comparing a sample's own stamps against times recorded on the wall clock.
+   */
+  public static long toWallClock(SampleResult result, long resultClockMillis) {
+    return resultClockMillis + (System.currentTimeMillis() - result.currentTimeInMillis());
+  }
+
+  /**
+   * Converts a time held by {@code source} into {@code target}'s clock. Two results capture their
+   * offset from the refreshing one at whatever moment each was constructed, so a sample and a
+   * sub-sample of it are on the same clock only as long as no refresh happened in between - which
+   * for a transaction holding a think time is not a given.
+   *
+   * <p>The same correction {@code SampleResult.addSubResult} applies for JMeter's Bug 51855 when it
+   * extends a parent's end time with a sub-result's, expressed through the public clock rather than
+   * the private offset field the class reads there.
+   */
+  public static long fromResultClock(SampleResult target, SampleResult source, long time) {
+    return time + (target.currentTimeInMillis() - source.currentTimeInMillis());
+  }
+
+  /**
+   * Stamps a sample that was timed outside of it: {@code start} on the result's own clock (see
+   * {@link #fromNanoTime}) and how long it took. Both come out of the sample as given, whichever
+   * end of the interval {@code sampleresult.timestamp.start} makes
+   * {@link SampleResult#setStampAndTime(long, long)} take as its stamp.
+   *
+   * @throws IllegalStateException if {@code result} is already stamped, as
+   *                               {@code setStampAndTime} does
+   */
+  public static void stampInterval(SampleResult result, long start, long elapsedMillis) {
+    result.setStampAndTime(STAMP_IS_START ? start : start + elapsedMillis, elapsedMillis);
+  }
+
+  /** Mirrors {@code SampleResult.sampleNsClockInMs()}, truncation to whole millis included. */
+  private static long nanoClockMillis(long nanoTime) {
+    return nanoTime / 1_000_000L;
+  }
+
+  private static boolean probeStampIsStart() {
+    SampleResult probe = new SampleResult();
+    probe.setStampAndTime(1_000L, 100L);
+    return probe.getStartTime() == 1_000L;
+  }
+}

--- a/src/main/java/com/blazemeter/jmeter/http2/core/jetty/custom/http2/CustomClientConnectionFactoryOverHTTP2.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/jetty/custom/http2/CustomClientConnectionFactoryOverHTTP2.java
@@ -2,8 +2,10 @@ package com.blazemeter.jmeter.http2.core.jetty.custom.http2;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import org.eclipse.jetty.client.Connection;
 import org.eclipse.jetty.client.Destination;
 import org.eclipse.jetty.client.HttpClient;
@@ -24,9 +26,16 @@ public class CustomClientConnectionFactoryOverHTTP2 extends ContainerLifeCycle
     implements ClientConnectionFactory, HttpClient.Aware {
   private final ClientConnectionFactory factory = new CustomHTTP2ClientConnectionFactory();
   private final HTTP2Client http2Client;
+  private final Consumer<URI> onHttp2Rejected;
 
   public CustomClientConnectionFactoryOverHTTP2(HTTP2Client http2Client) {
+    this(http2Client, null);
+  }
+
+  public CustomClientConnectionFactoryOverHTTP2(HTTP2Client http2Client,
+      Consumer<URI> onHttp2Rejected) {
     this.http2Client = http2Client;
+    this.onHttp2Rejected = onHttp2Rejected;
     installBean(http2Client);
   }
 
@@ -39,7 +48,7 @@ public class CustomClientConnectionFactoryOverHTTP2 extends ContainerLifeCycle
   public org.eclipse.jetty.io.Connection newConnection(EndPoint endPoint,
       Map<String, Object> context) throws IOException {
     CustomHttpSessionListenerPromise listenerPromise = new CustomHttpSessionListenerPromise(
-        context);
+        context, onHttp2Rejected);
     context.put(HTTP2Client.CONTEXT_KEY, http2Client);
     context.put(HTTP2Client.SESSION_LISTENER_CONTEXT_KEY, listenerPromise);
     context.put(HTTP2Client.SESSION_PROMISE_CONTEXT_KEY, listenerPromise);
@@ -50,11 +59,16 @@ public class CustomClientConnectionFactoryOverHTTP2 extends ContainerLifeCycle
     private final List<String> protocols;
 
     public HTTP2(HTTP2Client http2Client) {
-      this(http2Client, List.of("h2", "h2-17", "h2-16", "h2-15"));
+      this(http2Client, null);
     }
 
-    public HTTP2(HTTP2Client http2Client, List<String> protocols) {
-      super(new CustomClientConnectionFactoryOverHTTP2(http2Client));
+    public HTTP2(HTTP2Client http2Client, Consumer<URI> onHttp2Rejected) {
+      this(http2Client, List.of("h2", "h2-17", "h2-16", "h2-15"), onHttp2Rejected);
+    }
+
+    public HTTP2(HTTP2Client http2Client, List<String> protocols,
+        Consumer<URI> onHttp2Rejected) {
+      super(new CustomClientConnectionFactoryOverHTTP2(http2Client, onHttp2Rejected));
       this.protocols = protocols;
     }
 

--- a/src/main/java/com/blazemeter/jmeter/http2/core/jetty/custom/http2/CustomHttpClientTransportOverHTTP2.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/jetty/custom/http2/CustomHttpClientTransportOverHTTP2.java
@@ -1,6 +1,8 @@
 package com.blazemeter.jmeter.http2.core.jetty.custom.http2;
 
+import com.blazemeter.jmeter.http2.core.ConnectAttemptRecorder;
 import java.io.IOException;
+import java.net.SocketAddress;
 import java.util.Map;
 import org.eclipse.jetty.http2.client.HTTP2Client;
 import org.eclipse.jetty.http2.client.transport.HttpClientTransportOverHTTP2;
@@ -14,9 +16,29 @@ public class CustomHttpClientTransportOverHTTP2 extends HttpClientTransportOverH
 
   private final CustomHTTP2ClientConnectionFactory connectionFactory =
       new CustomHTTP2ClientConnectionFactory();
+  private final ConnectAttemptRecorder connectAttempts;
 
   public CustomHttpClientTransportOverHTTP2(HTTP2Client http2Client) {
+    this(http2Client, null);
+  }
+
+  public CustomHttpClientTransportOverHTTP2(HTTP2Client http2Client,
+                                            ConnectAttemptRecorder connectAttempts) {
     super(http2Client);
+    this.connectAttempts = connectAttempts;
+  }
+
+  /**
+   * Lets the recorder see this address's failure before Jetty moves on to the next resolved
+   * address. This transport carries h2c prior knowledge, where the preface is sent with no ALPN
+   * to fall back on, so a server that does not speak HTTP/2 fails exactly here.
+   */
+  @Override
+  public void connect(SocketAddress address, Map<String, Object> context) {
+    if (connectAttempts != null) {
+      connectAttempts.instrument(address, context);
+    }
+    super.connect(address, context);
   }
 
   @Override

--- a/src/main/java/com/blazemeter/jmeter/http2/core/jetty/custom/http2/CustomHttpSessionListenerPromise.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/jetty/custom/http2/CustomHttpSessionListenerPromise.java
@@ -1,23 +1,83 @@
 package com.blazemeter.jmeter.http2.core.jetty.custom.http2;
 
+import java.net.URI;
 import java.util.Map;
+import java.util.function.Consumer;
 import org.eclipse.jetty.client.Connection;
 import org.eclipse.jetty.client.Destination;
 import org.eclipse.jetty.http2.HTTP2Connection;
 import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.http2.client.transport.internal.HTTPSessionListenerPromise;
+import org.eclipse.jetty.http2.frames.GoAwayFrame;
+import org.eclipse.jetty.util.Callback;
 
 /**
- * Custom session listener that creates custom HTTP/2 connections.
+ * Custom session listener that creates custom HTTP/2 connections, and reports the origins that
+ * turn out not to speak HTTP/2 at all.
+ *
+ * <p>A peer that never agreed to {@code h2} - because the TLS handshake selected no ALPN protocol,
+ * which a TLS-inspecting proxy produces and RFC 7301 permits - still gets the HTTP/2 preface, since
+ * Jetty falls back to the first configured protocol when ALPN negotiated nothing. It answers with
+ * HTTP/1.1 bytes, the parser rejects them, and the session dies before the server preface ever
+ * arrives.
+ *
+ * <p>That last part is the discriminator, and Jetty already relies on it: its own
+ * {@code failConnectionPromise} only fires while the connection reference is still unset, which is
+ * exactly "the server preface never arrived". {@link #newConnection} is called when it does
+ * arrive, so tracking that separates a peer that cannot speak HTTP/2 from a healthy session being
+ * closed - a distinction that matters, because marking an origin on a normal GOAWAY would break
+ * reconnection.
  */
 public class CustomHttpSessionListenerPromise extends HTTPSessionListenerPromise {
+
+  private final Map<String, Object> context;
+  private final Consumer<URI> onHttp2Rejected;
+
+  private volatile boolean serverPrefaceSeen;
+
   public CustomHttpSessionListenerPromise(Map<String, Object> context) {
+    this(context, null);
+  }
+
+  public CustomHttpSessionListenerPromise(Map<String, Object> context,
+                                          Consumer<URI> onHttp2Rejected) {
     super(context);
+    this.context = context;
+    this.onHttp2Rejected = onHttp2Rejected;
   }
 
   @Override
   protected Connection newConnection(Destination destination, Session session,
       HTTP2Connection connection) {
+    serverPrefaceSeen = true;
     return new CustomHttpConnectionOverHTTP2(destination, session, connection);
+  }
+
+  /**
+   * Where a peer that does not speak HTTP/2 surfaces: the parser rejects the answer to the preface
+   * and fails the session. Verified against a TLS server that selects no ALPN protocol, which
+   * reports {@code frame_size_error/invalid_frame_length} here with no server preface seen.
+   */
+  @Override
+  public void onFailure(Session session, Throwable failure, Callback callback) {
+    reportHttp2RejectedIfPrefaceNeverArrived();
+    super.onFailure(session, failure, callback);
+  }
+
+  @Override
+  public void onClose(Session session, GoAwayFrame frame, Callback callback) {
+    reportHttp2RejectedIfPrefaceNeverArrived();
+    super.onClose(session, frame, callback);
+  }
+
+  private void reportHttp2RejectedIfPrefaceNeverArrived() {
+    if (serverPrefaceSeen || onHttp2Rejected == null) {
+      return;
+    }
+    Destination destination = (Destination) context.get(Destination.CONTEXT_KEY);
+    if (destination == null) {
+      return;
+    }
+    onHttp2Rejected.accept(URI.create(destination.getOrigin().asString()));
   }
 }

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -476,25 +476,31 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
       if ((isProtocolErrorCause || isProtocolErrorException)
           && !HpackFailureDetector.indicatesHpackFailure(e)
           && !HpackFailureDetector.indicatesHpackFailure(cause)) {
-        boolean fallbackEnabled = isProtocolErrorFallbackEnabled();
+        HTTP2JettyClient fallbackClient = resolveClientForFallback();
+        // The client owns the resolved answer: it already merges this sampler's own flags with
+        // the JMeter properties, and it already turns the fallback off when HTTP/1.1 is disabled.
+        // Re-deriving it from properties alone here ignored both, and retried over HTTP/1.1 even
+        // against h2c-only endpoints where no request may go out as HTTP/1.1.
+        boolean fallbackEnabled =
+            fallbackClient != null && fallbackClient.isProtocolErrorFallbackEnabled();
         if (!fallbackEnabled) {
           LOG.warn("HTTP/2 protocol_error detected and fallback is DISABLED. "
               + "Request will fail.");
           LOG.warn("Error: {}", cause != null ? cause.getMessage() : e.getMessage());
           LOG.warn("To enable fallback, set blazemeter.http.protocolErrorFallbackEnabled=true "
-              + "or blazemeter.http.disableFallback=false in user.properties or jmeter.properties");
+              + "or blazemeter.http.disableFallback=false in user.properties or jmeter.properties, "
+              + "and keep HTTP/1.1 enabled on the sampler");
         } else {
           LOG.warn("HTTP/2 protocol_error detected. Attempting fallback to HTTP/1.1");
           LOG.warn("Error: {}", cause != null ? cause.getMessage() : e.getMessage());
 
           try {
-            // Get the client and request details for fallback
-            HTTP2JettyClient client = clientFactory.call();
             HTTPSampleResult fallbackBase = resolveErrorResult(preparedResult, url, method);
 
             // Retry with HTTP/1.1 only
             LOG.info("Retrying request with HTTP/1.1 only: {}", url);
-            HTTPSampleResult fallbackResult = client.retryWithHTTP11Only(this, fallbackBase);
+            HTTPSampleResult fallbackResult =
+                fallbackClient.retryWithHTTP11Only(this, fallbackBase);
 
             if (fallbackResult != null && fallbackResult.isSuccessful()) {
               LOG.info("HTTP/1.1 fallback succeeded: status={}", fallbackResult.getResponseCode());
@@ -523,17 +529,17 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
     return buildResult(url, method);
   }
 
-  private boolean isProtocolErrorFallbackEnabled() {
-    String fb =
-        BzmHttpPluginProperties.resolveRaw("httpJettyClient.protocolErrorFallbackEnabled");
-    if (fb != null) {
-      return Boolean.parseBoolean(fb);
+  /**
+   * The client that would serve this sampler, or {@code null} when it cannot be obtained. Used
+   * from the failure path, where losing the client means there is nothing left to retry on.
+   */
+  private HTTP2JettyClient resolveClientForFallback() {
+    try {
+      return clientFactory.call();
+    } catch (Exception e) {
+      LOG.error("Could not obtain the client to evaluate the HTTP/1.1 fallback", e);
+      return null;
     }
-    String df = BzmHttpPluginProperties.resolveRaw("httpJettyClient.disableFallback");
-    if (df != null) {
-      return !Boolean.parseBoolean(df);
-    }
-    return true;
   }
 
   protected Request sampleAsync(HTTPSampleResult result, HTTP2FutureResponseListener listener)

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -6,6 +6,7 @@ import com.blazemeter.jmeter.http2.core.HTTP2ClientProfileConfig;
 import com.blazemeter.jmeter.http2.core.HTTP2FutureResponseListener;
 import com.blazemeter.jmeter.http2.core.HTTP2JettyClient;
 import com.blazemeter.jmeter.http2.core.HpackFailureDetector;
+import com.blazemeter.jmeter.http2.core.JMeterSourceAddressResolver;
 import com.blazemeter.jmeter.http2.core.JmeterHttpClientExceptionMapper;
 import com.blazemeter.jmeter.http2.core.ProtocolErrorException;
 import com.blazemeter.jmeter.http2.util.BzmHttpPluginProperties;
@@ -16,6 +17,7 @@ import com.helger.commons.annotation.VisibleForTesting;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.ConnectException;
+import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.SocketTimeoutException;
 import java.net.URISyntaxException;
@@ -873,9 +875,15 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
 
   private HTTP2JettyClient buildClient() throws Exception {
     HTTP2ClientKey connectionKey = buildConnectionKey();
+    // Resolved before the client exists: a bad source address must fail the sample without
+    // leaving an orphaned client behind, and it is the cheapest thing here to get wrong.
+    InetAddress sourceAddress = resolveSourceAddress();
     HTTP2JettyClient client = new HTTP2JettyClient(isHttp1UpgradeEnabled(),
         "http2[" + connectionKey.target + ":" + Thread.currentThread().getId() + "]",
         buildProfileConfig(), getDNSResolver());
+    if (sourceAddress != null) {
+      client.setSourceAddress(sourceAddress);
+    }
     client.start();
     CONNECTIONS.get().put(connectionKey, client);
     return client;
@@ -924,8 +932,37 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
     appendLongKey(key, "h1cd", getHttp1OnlyCooldownMs());
     appendLongKey(key, "h2cttl", getH2cCacheTtlMs());
     appendBooleanKey(key, "h2cup", isHttp1UpgradeEnabled());
+    appendSourceAddressKey(key);
     appendDnsResolverKey(key);
     return key.toString();
+  }
+
+  /**
+   * The local address outgoing connections must be bound to - the sampler's "Source address"
+   * field (IP spoofing), or the {@code httpclient.localaddress} property.
+   *
+   * <p>A bad host name, IP or interface propagates out and fails the sample, which is what HC4
+   * does by letting {@code getIpSourceAddress} throw out of {@code setupRequest}. Silently falling
+   * back to the default interface would make a spoofing plan look like it works while every
+   * request leaves from the wrong address.
+   */
+  private InetAddress resolveSourceAddress() throws Exception {
+    if (!JMeterSourceAddressResolver.isConfigured(this)) {
+      return null;
+    }
+    return JMeterSourceAddressResolver.resolve(this);
+  }
+
+  /**
+   * Jetty binds the source address per client, not per request, so a cached client carries the one
+   * it was built with. Keying on the raw configuration - not on the resolved address - keeps this
+   * off the per-sample path: resolving a device name walks the interface list.
+   */
+  private void appendSourceAddressKey(StringBuilder key) {
+    String sourceAddress = JMeterSourceAddressResolver.cacheKeyFor(this);
+    if (!sourceAddress.isEmpty()) {
+      key.append(";ipsrc=").append(sourceAddress);
+    }
   }
 
   /**

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -9,6 +9,7 @@ import com.blazemeter.jmeter.http2.core.HpackFailureDetector;
 import com.blazemeter.jmeter.http2.core.JMeterSourceAddressResolver;
 import com.blazemeter.jmeter.http2.core.JmeterHttpClientExceptionMapper;
 import com.blazemeter.jmeter.http2.core.ProtocolErrorException;
+import com.blazemeter.jmeter.http2.core.SampleClock;
 import com.blazemeter.jmeter.http2.util.BzmHttpPluginProperties;
 import com.blazemeter.jmeter.http2.util.Rfc9110Redirects;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -30,6 +31,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import java.util.regex.PatternSyntaxException;
@@ -572,8 +574,13 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
       result.sampleStart();
     }
     if (result.getEndTime() == 0) {
-      if (!Objects.isNull(this.asyncListener) && this.asyncListener.getResponseEnd() != 0) {
-        result.setEndTime(this.asyncListener.getResponseEnd());
+      // On this result's own clock: its start came from sampleStart(), and the listener records the
+      // exchange on the wall clock. See SampleClock.
+      long responseEnd = Objects.isNull(this.asyncListener)
+          ? 0
+          : this.asyncListener.getResponseEndOn(result);
+      if (responseEnd > 0) {
+        result.setEndTime(responseEnd);
       } else {
         result.sampleEnd();
       }
@@ -591,6 +598,11 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
    * <p>Reads the client already cached for this thread instead of asking the factory: building one
    * here would be a side effect on the error path, and a sample that never got that far has
    * nothing recorded anyway.
+   *
+   * <p>The recorder keeps its attempts on the wall clock, so the sample's own start is converted
+   * before being used to select them: comparing the two clocks directly dropped attempts of this
+   * very sample, or picked up attempts of the previous one, by however far apart the clocks were.
+   * See {@link SampleClock}.
    */
   private void attachConnectAttempts(Throwable failure, HTTPSampleResult result) {
     if (failure == null || result.getURL() == null) {
@@ -599,7 +611,11 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
     try {
       HTTP2JettyClient client = CONNECTIONS.get().get(buildConnectionKey());
       if (client != null) {
-        client.attachConnectAttempts(failure, result.getURL(), result.getStartTime());
+        long sampleStart = result.getStartTime();
+        client.attachConnectAttempts(failure, result.getURL(),
+            // 0 is the recorder's "everything held", and must stay a 0 rather than become the
+            // distance between the clocks.
+            sampleStart == 0 ? 0 : SampleClock.toWallClock(result, sampleStart));
       }
     } catch (Exception ignored) {
       // Diagnostics must never replace the failure the sample is actually reporting.
@@ -650,11 +666,12 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
    * {@code sampleStart}/{@code sampleEnd} back-to-back left elapsed at ~0 and made the page look
    * like it finished when the last fast image landed.
    *
-   * @param startedAtMs when this resource's attempt began (dispatch / listener start), used as the
-   *                    sample start so the reported duration matches the timeout wait
+   * @param startedAtNanos {@link System#nanoTime()} when this resource's attempt began (dispatch /
+   *                       listener start). Monotonic, so the reported duration is the wait itself
+   *                       and not the wait plus whatever the machine clock did meanwhile
    */
   private HTTPSampleResult embeddedTimeoutErrorResult(HTTP2Sampler embeddedSampler,
-                                                      long startedAtMs) {
+                                                      long startedAtNanos) {
     HTTPSampleResult err = new HTTPSampleResult();
     URL url = resolveEmbeddedResourceUrl(embeddedSampler);
     if (url != null) {
@@ -666,21 +683,25 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
       err.setSampleLabel(embeddedSampler.getName());
     }
     err.setHTTPMethod(HTTPConstants.GET);
-    long endedAtMs = System.currentTimeMillis();
-    long elapsedMs = Math.max(0L, endedAtMs - startedAtMs);
-    // SampleResult.setStampAndTime(stamp, elapsed) treats stamp as start (end = stamp + elapsed).
-    err.setStampAndTime(startedAtMs, elapsedMs);
+    long elapsedMs =
+        Math.max(0L, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAtNanos));
+    // Start on this result's own clock and the wait measured monotonically, so both the timestamps
+    // and the duration hold whichever end of the interval setStampAndTime takes as its stamp.
+    SampleClock.stampInterval(err, SampleClock.fromNanoTime(err, startedAtNanos), elapsedMs);
     err.setConnectTime(0L);
     err.setLatency(0L);
     return errorResult(new SocketTimeoutException("Read timed out"), err);
   }
 
-  private long embeddedAttemptStartMillis(HTTP2Sampler embeddedSampler) {
+  /**
+   * When this resource's attempt went out, as a {@link System#nanoTime()} reading, falling back to
+   * now for a sampler whose request never reached the transport.
+   */
+  private long embeddedAttemptStartNanos(HTTP2Sampler embeddedSampler) {
     HTTP2FutureResponseListener listener = embeddedSampler.getFutureResponseListener();
-    if (listener != null && listener.getResponseStart() > 0) {
-      return listener.getResponseStart();
-    }
-    return System.currentTimeMillis();
+    return listener == null
+        ? System.nanoTime()
+        : listener.getResponseStartNanos().orElseGet(System::nanoTime);
   }
 
   private URL resolveEmbeddedResourceUrl(HTTP2Sampler embeddedSampler) {
@@ -710,12 +731,12 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
     samplers.clear();
     for (TestElement element : pending) {
       HTTP2Sampler embedded = (HTTP2Sampler) element;
-      long startedAtMs = embeddedAttemptStartMillis(embedded);
+      long startedAtNanos = embeddedAttemptStartNanos(embedded);
       HTTP2FutureResponseListener listener = embedded.getFutureResponseListener();
       if (listener != null && !listener.isDone() && !listener.isCancelled()) {
         listener.cancel(true);
       }
-      subres.addSubResult(embeddedTimeoutErrorResult(embedded, startedAtMs));
+      subres.addSubResult(embeddedTimeoutErrorResult(embedded, startedAtNanos));
     }
     setParentSampleSuccess(subres, false);
   }
@@ -1642,9 +1663,9 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
     // queue instead would grant it a fresh full timeout on top of however long it already waited;
     // timing the whole page from a single start (as this used to) went the other way and expired
     // resources that had in fact completed normally.
-    long start = listener.getResponseStart() > 0
-        ? listener.getResponseStart()
-        : System.currentTimeMillis();
+    // Monotonic: a wall clock that steps back mid-page would hold a resource past its timeout, and
+    // one that steps forward would expire a resource that is still well within it.
+    long startNanos = embeddedAttemptStartNanos(embeddedSampler);
     while (true) {
       if (listener.isDone() || listener.isCancelled()) {
         consumeFirstEmbeddedSampler(samplers, subres);
@@ -1656,7 +1677,8 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
         abortPendingEmbeddedRequests(samplers);
         return true;
       }
-      if (embeddedTimeout > 0 && (System.currentTimeMillis() - start) >= embeddedTimeout) {
+      if (embeddedTimeout > 0
+          && TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos) >= embeddedTimeout) {
         String pendingUrl = listener.getRequest() != null
             ? listener.getRequest().getURI().toString()
             : "unknown";
@@ -1668,7 +1690,7 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
         // of the page container.
         samplers.remove(0);
         listener.cancel(true);
-        subres.addSubResult(embeddedTimeoutErrorResult(embeddedSampler, start));
+        subres.addSubResult(embeddedTimeoutErrorResult(embeddedSampler, startNanos));
         setParentSampleSuccess(subres, false);
         return false;
       }

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -636,8 +636,8 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
     err.setHTTPMethod(HTTPConstants.GET);
     long endedAtMs = System.currentTimeMillis();
     long elapsedMs = Math.max(0L, endedAtMs - startedAtMs);
-    // Stamp end = now, start = now - elapsed (same contract as a real timed-out HC4 sample).
-    err.setStampAndTime(endedAtMs, elapsedMs);
+    // SampleResult.setStampAndTime(stamp, elapsed) treats stamp as start (end = stamp + elapsed).
+    err.setStampAndTime(startedAtMs, elapsedMs);
     err.setConnectTime(0L);
     err.setLatency(0L);
     return errorResult(new SocketTimeoutException("Read timed out"), err);

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -37,6 +37,7 @@ import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.engine.event.LoopIterationEvent;
 import org.apache.jmeter.engine.event.LoopIterationListener;
 import org.apache.jmeter.processor.PreProcessor;
+import org.apache.jmeter.protocol.http.control.DNSCacheManager;
 import org.apache.jmeter.protocol.http.parser.BaseParser;
 import org.apache.jmeter.protocol.http.parser.LinkExtractorParseException;
 import org.apache.jmeter.protocol.http.parser.LinkExtractorParser;
@@ -874,7 +875,7 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
     HTTP2ClientKey connectionKey = buildConnectionKey();
     HTTP2JettyClient client = new HTTP2JettyClient(isHttp1UpgradeEnabled(),
         "http2[" + connectionKey.target + ":" + Thread.currentThread().getId() + "]",
-        buildProfileConfig());
+        buildProfileConfig(), getDNSResolver());
     client.start();
     CONNECTIONS.get().put(connectionKey, client);
     return client;
@@ -923,7 +924,20 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
     appendLongKey(key, "h1cd", getHttp1OnlyCooldownMs());
     appendLongKey(key, "h2cttl", getH2cCacheTtlMs());
     appendBooleanKey(key, "h2cup", isHttp1UpgradeEnabled());
+    appendDnsResolverKey(key);
     return key.toString();
+  }
+
+  /**
+   * A cached client carries the DNS Cache Manager it was built with, so two samplers under
+   * different managers (or one with a manager and one without) must not share it. Identity is
+   * enough: JMeter clones the manager once per thread and the client cache is per thread too, so
+   * the instance is stable for as long as the entry can be reused.
+   */
+  private void appendDnsResolverKey(StringBuilder key) {
+    DNSCacheManager dnsCacheManager = getDNSResolver();
+    key.append(";dns=")
+        .append(dnsCacheManager == null ? "-" : System.identityHashCode(dnsCacheManager));
   }
 
   private void appendBooleanKey(StringBuilder key, String name, Boolean value) {

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -572,9 +572,32 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
         result.sampleEnd();
       }
     }
-    return errorResult(
-        JmeterHttpClientExceptionMapper.forSampleResult(e, getAutoRedirects(), result.getURL()),
-        result);
+    Throwable failure =
+        JmeterHttpClientExceptionMapper.forSampleResult(e, getAutoRedirects(), result.getURL());
+    attachConnectAttempts(failure, result);
+    return errorResult(failure, result);
+  }
+
+  /**
+   * Recovers the per-address connection failures Jetty discarded while walking the resolved
+   * addresses, so the response data shows every address tried and why, not only the last one.
+   *
+   * <p>Reads the client already cached for this thread instead of asking the factory: building one
+   * here would be a side effect on the error path, and a sample that never got that far has
+   * nothing recorded anyway.
+   */
+  private void attachConnectAttempts(Throwable failure, HTTPSampleResult result) {
+    if (failure == null || result.getURL() == null) {
+      return;
+    }
+    try {
+      HTTP2JettyClient client = CONNECTIONS.get().get(buildConnectionKey());
+      if (client != null) {
+        client.attachConnectAttempts(failure, result.getURL(), result.getStartTime());
+      }
+    } catch (Exception ignored) {
+      // Diagnostics must never replace the failure the sample is actually reporting.
+    }
   }
 
   /**

--- a/src/test/java/com/blazemeter/jmeter/http2/control/HTTP2ControllerTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/control/HTTP2ControllerTest.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.jmeter.control.NextIsNullException;
+import org.apache.jmeter.control.TransactionController;
 import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
 import org.apache.jmeter.protocol.http.sampler.HTTPSampler;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
@@ -230,6 +231,40 @@ public class HTTP2ControllerTest extends HTTP2TestBase {
     c.setProperty(BzmHttpPluginProperties.CONTROLLER_LEGACY_PREFIX + "limitMaxParallel", false);
     c.setProperty(BzmHttpPluginProperties.CONTROLLER_PREFERRED_PREFIX + "limitMaxParallel", true);
     assertThat(c.isLimitMaxParallel()).isTrue();
+  }
+
+  /**
+   * Issue #155: inheriting JMeter's default of {@code true} is what put the think time inside the
+   * transaction time, since no existing JMX carries the property.
+   */
+  @Test
+  public void includeTimersDefaultsToFalseUnlikeAStockTransactionController() {
+    JMeterTestUtils.setupJmeterEnv();
+    assertThat(new TransactionController().isIncludeTimers()).isTrue();
+    assertThat(new HTTP2Controller().isIncludeTimers()).isFalse();
+  }
+
+  @Test
+  public void includeTimersIsHonoredWhenSetOnTheElement() {
+    JMeterTestUtils.setupJmeterEnv();
+    HTTP2Controller c = new HTTP2Controller();
+    // A JMX written against a stock Transaction Controller carries exactly this.
+    c.setProperty("TransactionController.includeTimers", true);
+    assertThat(c.isIncludeTimers()).isTrue();
+  }
+
+  /**
+   * {@code TransactionController.setIncludeTimers} drops the property when it matches JMeter's own
+   * default of {@code true}, which would silently discard the user's choice here.
+   */
+  @Test
+  public void includeTimersSurvivesBeingSetToTrueThroughTheSetter() {
+    JMeterTestUtils.setupJmeterEnv();
+    HTTP2Controller c = new HTTP2Controller();
+    c.setIncludeTimers(true);
+    assertThat(c.isIncludeTimers()).isTrue();
+    c.setIncludeTimers(false);
+    assertThat(c.isIncludeTimers()).isFalse();
   }
 
   private static class FlagHTTP2Sampler extends HTTP2Sampler {

--- a/src/test/java/com/blazemeter/jmeter/http2/control/HTTP2ControllerTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/control/HTTP2ControllerTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.jmeter.control.NextIsNullException;
 import org.apache.jmeter.control.TransactionController;
+import org.apache.jmeter.control.TransactionSampler;
 import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
 import org.apache.jmeter.protocol.http.sampler.HTTPSampler;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
@@ -231,6 +232,30 @@ public class HTTP2ControllerTest extends HTTP2TestBase {
     c.setProperty(BzmHttpPluginProperties.CONTROLLER_LEGACY_PREFIX + "limitMaxParallel", false);
     c.setProperty(BzmHttpPluginProperties.CONTROLLER_PREFERRED_PREFIX + "limitMaxParallel", true);
     assertThat(c.isLimitMaxParallel()).isTrue();
+  }
+
+  /**
+   * Issue #155: a transaction that is still open must already carry an end time, because nothing
+   * guarantees it will be closed by this controller. {@code JMeterThread} ends whatever transaction
+   * is open when a run is cut short, without going through {@code setTransactionDone}, and an end
+   * time left at 0 makes {@code elapsed = end - start} report minus the epoch - directly when the
+   * controller is at the top level, and through {@code addSubResult}'s {@code Math.max} when it is
+   * nested in another transaction.
+   */
+  @Test
+  public void anOpenParentTransactionAlreadyCarriesAnEndTime() throws URISyntaxException {
+    setupHttp2Controller(false, 1);
+    http2Controller.setGenerateControllerSample(true);
+    // GenericController.first has no initialiser, so a controller that was never initialised never
+    // opens its transaction. JMeter does this before the run.
+    http2Controller.initialize();
+
+    Sampler first = http2Controller.next();
+
+    assertThat(first).isInstanceOf(TransactionSampler.class);
+    SampleResult parent = ((TransactionSampler) first).getTransactionResult();
+    assertThat(parent.getEndTime()).as("end time of an open transaction").isPositive();
+    assertThat(parent.getTime()).as("reported time of an open transaction").isNotNegative();
   }
 
   /**

--- a/src/test/java/com/blazemeter/jmeter/http2/control/async/AsyncControllerTransactionTimingTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/control/async/AsyncControllerTransactionTimingTest.java
@@ -1,0 +1,259 @@
+package com.blazemeter.jmeter.http2.control.async;
+
+import static com.blazemeter.jmeter.http2.control.async.AsyncScenarioRunner.node;
+import static com.blazemeter.jmeter.http2.control.async.AsyncScenarioRunner.threadGroup;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.control.async.ScenarioFixture.ControllerKind;
+import com.blazemeter.jmeter.http2.control.async.ScenarioFixture.Result;
+import com.blazemeter.jmeter.http2.control.async.ScenarioFixture.TreeShape;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import org.apache.jmeter.control.TransactionController;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.threads.JMeterThread;
+import org.apache.jmeter.threads.ThreadGroup;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Test;
+
+/**
+ * Issue #155 — "Think time is included in Transaction Time + Spurious Averages/Mins + Negative Last
+ * Sample Time", a v3.1.0 regression against v3.0.1.
+ *
+ * <p>What the parent sample of this controller must measure is the wall clock the controller spent
+ * on its requests: for a sequential controller that is the sum of the child times, and for a
+ * parallel one it is the span from the first dispatch to the last response. Timers and pre/post
+ * processors are pauses, not request time, so they are excluded — which is what v3.0.1 did by
+ * building the parent sample from {@code min(child start)} to {@code max(child end)}.
+ *
+ * <p>The stock Transaction Controller is deliberately NOT the baseline for the times here, unlike
+ * the rest of this suite: it runs its children sequentially, so span and sum coincide for it, and
+ * its own {@code includeTimers} defaults to {@code true}, so its parent sample counts the think
+ * time on purpose. Only {@link #t4ATransactionCutShortMustNotReportANegativeSampleTime()} compares
+ * against it, because there stock defines what "not broken" looks like.
+ */
+public class AsyncControllerTransactionTimingTest extends HTTP2TestBase {
+
+  private static final long LATENCY = 120L;
+  private static final long THINK_TIME = 800L;
+
+  @Test
+  public void t1ThinkTimeMustNotBeCountedInTheParentSampleTime() {
+    TreeShape shape = fixture -> new AsyncScenarioRunner.Node[]{
+        node(fixture.controller("controller"),
+            node(fixture.http("S1", LATENCY), node(fixture.timer("think-time", THINK_TIME))),
+            node(fixture.http("S2", LATENCY)))
+    };
+    Result actual = execute(ControllerKind.ASYNC_PARENT, 1, shape);
+    SampleResult parent = actual.topLevelResult("controller");
+    report("T1 controller[S1[think time " + THINK_TIME + "ms], S2]", actual, parent);
+
+    SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(parent).as("a parent sample must be reported").isNotNull();
+    if (parent != null) {
+      softly.assertThat(parent.getTime())
+          .as("the %s ms think time of S1 is a pause, not request time, so it must stay out of the "
+              + "controller's own sample time", THINK_TIME)
+          .isLessThan(THINK_TIME);
+      softly.assertThat(parent.getTime())
+          .as("the parent sample must measure the span of its requests")
+          .isEqualTo(requestSpan(parent));
+      softly.assertThat(parent.getTime())
+          .as("a sample time can never be negative")
+          .isNotNegative();
+    }
+    softly.assertAll();
+  }
+
+  @Test
+  public void t2ParentSampleTimeMustBeTheSpanOfTheOverlappedRequestsNotTheirSum() {
+    TreeShape shape = fixture -> new AsyncScenarioRunner.Node[]{
+        node(fixture.controller("controller"),
+            node(fixture.http("S1", 300)),
+            node(fixture.http("S2", 300)),
+            node(fixture.http("S3", 300)))
+    };
+    Result actual = execute(ControllerKind.ASYNC_PARENT, 1, shape);
+    SampleResult parent = actual.topLevelResult("controller");
+    report("T2 controller[S1, S2, S3] all 300ms", actual, parent);
+
+    SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(actual.maxConcurrentInFlight())
+        .as("precondition: the requests really overlapped")
+        .isGreaterThan(1);
+    softly.assertThat(parent).as("a parent sample must be reported").isNotNull();
+    if (parent != null) {
+      softly.assertThat(parent.getTime())
+          .as("three requests that ran at the same time took as long as the slowest of them, not "
+              + "as long as all of them one after another (%s ms)", sumOfChildTimes(parent))
+          .isLessThan(sumOfChildTimes(parent));
+      softly.assertThat(parent.getTime())
+          .as("the parent sample must measure the span of its requests")
+          .isEqualTo(requestSpan(parent));
+    }
+    softly.assertAll();
+  }
+
+  @Test
+  public void t3ThinkTimeMustNotBubbleUpToAnEnclosingTransactionController() {
+    TreeShape shape = fixture -> new AsyncScenarioRunner.Node[]{
+        node(enclosingTransaction(fixture),
+            node(fixture.controller("controller"),
+                node(fixture.http("S1", LATENCY), node(fixture.timer("think-time", THINK_TIME))),
+                node(fixture.http("S2", LATENCY))))
+    };
+    Result actual = execute(ControllerKind.ASYNC_PARENT, 1, shape);
+    SampleResult outer = actual.topLevelResult("tx");
+    SampleResult inner = outer == null ? null : firstChild(outer);
+    report("T3 tx(parent, includeTimers=false)[controller[S1[think time], S2]]", actual, outer);
+
+    SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(outer).as("the enclosing transaction must be reported").isNotNull();
+    softly.assertThat(inner).as("the controller sample must be nested in it").isNotNull();
+    if (outer != null && inner != null) {
+      softly.assertThat(inner.getTime())
+          .as("the controller's own sample time must exclude the think time")
+          .isLessThan(THINK_TIME);
+      softly.assertThat(outer.getTime())
+          .as("an enclosing transaction sums the times of its children, so a think time counted by "
+              + "the controller bubbles straight up into it")
+          .isLessThan(THINK_TIME);
+      softly.assertThat(outer.getTime())
+          .as("the enclosing transaction has a single child, so it must report that child's time")
+          .isEqualTo(inner.getTime());
+    }
+    softly.assertAll();
+  }
+
+  @Test
+  public void t4ATransactionCutShortMustNotReportANegativeSampleTime() {
+    TreeShape shape = fixture -> new AsyncScenarioRunner.Node[]{
+        node(enclosingTransaction(fixture),
+            node(fixture.controller("controller"),
+                node(fixture.http("S1", LATENCY)),
+                node(fixture.http("S2", LATENCY))))
+    };
+    Result baseline = execute(ControllerKind.STOCK_TX_PARENT, 1, shape,
+        AsyncScenarioRunner.expiredScheduler());
+    Result actual = execute(ControllerKind.ASYNC_PARENT, 1, shape,
+        AsyncScenarioRunner.expiredScheduler());
+    System.out.println("\n=== T4 scheduler already expired, transaction cut short ==="
+        + "\n  stock: " + describeAll(baseline)
+        + "\n  async: " + describeAll(actual));
+
+    SoftAssertions softly = new SoftAssertions();
+    assertReportsDurationsNotEpochs(softly, "stock", baseline);
+    assertReportsDurationsNotEpochs(softly, "async", actual);
+    softly.assertAll();
+  }
+
+  /**
+   * The defect is a transaction that was never given an end time: {@code elapsed = end - start} then
+   * reports {@code 0 - startTime}, an epoch, and that single row wrecks the Average and the Min of
+   * every aggregate over the run. Both halves are asserted, since the missing end time is the cause
+   * and the negative duration is what a report shows.
+   */
+  private static void assertReportsDurationsNotEpochs(SoftAssertions softly, String kind,
+                                                      Result result) {
+    for (SampleResult sample : allResults(result)) {
+      softly.assertThat(sample.getEndTime())
+          .as("%s: '%s' was ended without an end time being stamped, which is what turns into "
+              + "0 - startTime", kind, sample.getSampleLabel())
+          .isPositive();
+      softly.assertThat(sample.getTime())
+          .as("%s: '%s' was reported with %s ms", kind, sample.getSampleLabel(), sample.getTime())
+          .isNotNegative();
+    }
+  }
+
+  /** Mirrors issue #155's test plan: parent sample on, think time excluded. */
+  private static TransactionController enclosingTransaction(ScenarioFixture fixture) {
+    TransactionController transaction = fixture.stockTransaction("tx", true);
+    transaction.setIncludeTimers(false);
+    return transaction;
+  }
+
+  /** From the first dispatch to the last response, i.e. what a parallel block really took. */
+  private static long requestSpan(SampleResult parent) {
+    long firstStart = Long.MAX_VALUE;
+    long lastEnd = 0;
+    for (SampleResult child : children(parent)) {
+      if (child.getStartTime() > 0) {
+        firstStart = Math.min(firstStart, child.getStartTime());
+      }
+      lastEnd = Math.max(lastEnd, child.getEndTime());
+    }
+    return firstStart == Long.MAX_VALUE ? 0 : lastEnd - firstStart;
+  }
+
+  private static long sumOfChildTimes(SampleResult parent) {
+    long total = 0;
+    for (SampleResult child : children(parent)) {
+      total += child.getTime();
+    }
+    return total;
+  }
+
+  private static SampleResult firstChild(SampleResult parent) {
+    List<SampleResult> children = children(parent);
+    return children.isEmpty() ? null : children.get(0);
+  }
+
+  private static List<SampleResult> children(SampleResult parent) {
+    SampleResult[] subs = parent == null ? null : parent.getSubResults();
+    return subs == null ? new ArrayList<>() : Arrays.asList(subs);
+  }
+
+  private static List<SampleResult> allResults(Result result) {
+    List<SampleResult> all = new ArrayList<>();
+    for (SampleResult top : result.topLevelResults()) {
+      collect(top, all);
+    }
+    return all;
+  }
+
+  private static void collect(SampleResult result, List<SampleResult> out) {
+    out.add(result);
+    for (SampleResult child : children(result)) {
+      collect(child, out);
+    }
+  }
+
+  private static String describeAll(Result result) {
+    StringBuilder out = new StringBuilder();
+    for (SampleResult sample : allResults(result)) {
+      out.append("\n         ").append(sample.getSampleLabel())
+          .append(": time=").append(sample.getTime())
+          .append(" start=").append(sample.getStartTime())
+          .append(" end=").append(sample.getEndTime())
+          .append(" idle=").append(sample.getIdleTime());
+    }
+    return out.length() == 0 ? "<no sample reported>" : out.toString();
+  }
+
+  private static void report(String label, Result result, SampleResult parent) {
+    System.out.println("\n=== " + label + " ==="
+        + "\n  reported: " + describeAll(result)
+        + "\n  span=" + requestSpan(parent) + " sum=" + sumOfChildTimes(parent)
+        + " maxInFlight=" + result.maxConcurrentInFlight());
+  }
+
+  private Result execute(ControllerKind kind, int loops, TreeShape shape) {
+    return execute(kind, loops, shape, thread -> {
+    });
+  }
+
+  private Result execute(ControllerKind kind, int loops, TreeShape shape,
+                         Consumer<JMeterThread> threadSetup) {
+    try (ScenarioFixture fixture = new ScenarioFixture(kind)) {
+      ThreadGroup group = threadGroup("tg", loops);
+      List<AsyncScenarioRunner.Node> nodes =
+          new ArrayList<>(Arrays.asList(shape.build(fixture)));
+      nodes.add(fixture.recorderNode());
+      return fixture.run(group, AsyncScenarioRunner.DEFAULT_TIMEOUT_MILLIS, threadSetup,
+          nodes.toArray(new AsyncScenarioRunner.Node[0]));
+    }
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/control/async/AsyncControllerTransactionTimingTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/control/async/AsyncControllerTransactionTimingTest.java
@@ -127,6 +127,15 @@ public class AsyncControllerTransactionTimingTest extends HTTP2TestBase {
     softly.assertAll();
   }
 
+  /**
+   * A Stop goes straight onto the running flag, so unlike the scheduled end of
+   * {@link #t5RequestsAlreadyOnTheWireMustSurviveTheScheduledEnd()} it cannot be held off: whatever
+   * this controller had on the wire is lost. What must not happen is a poisoned row getting out -
+   * the transaction that was open when the Stop landed reporting minus the epoch. Landing while the
+   * controller waits for a response, the Stop is seen by {@code JMeterThread}'s own loop before
+   * {@code processSampler} runs again, so usually nothing is reported at all; that the run stops,
+   * and that nothing bogus reaches a listener either way, is what is asserted.
+   */
   @Test
   public void t4ATransactionCutShortMustNotReportANegativeSampleTime() {
     TreeShape shape = fixture -> new AsyncScenarioRunner.Node[]{
@@ -136,14 +145,16 @@ public class AsyncControllerTransactionTimingTest extends HTTP2TestBase {
                 node(fixture.http("S2", LATENCY))))
     };
     Result baseline = execute(ControllerKind.STOCK_TX_PARENT, 1, shape,
-        AsyncScenarioRunner.expiredScheduler());
+        AsyncScenarioRunner.stopAfter(LATENCY / 4));
     Result actual = execute(ControllerKind.ASYNC_PARENT, 1, shape,
-        AsyncScenarioRunner.expiredScheduler());
-    System.out.println("\n=== T4 scheduler already expired, transaction cut short ==="
+        AsyncScenarioRunner.stopAfter(LATENCY / 4));
+    System.out.println("\n=== T4 stopped from the outside, mid-flight ==="
         + "\n  stock: " + describeAll(baseline)
         + "\n  async: " + describeAll(actual));
 
     SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(baseline.hung()).as("the stock run must stop").isFalse();
+    softly.assertThat(actual.hung()).as("the async run must stop").isFalse();
     assertReportsDurationsNotEpochs(softly, "stock", baseline);
     assertReportsDurationsNotEpochs(softly, "async", actual);
     softly.assertAll();
@@ -166,6 +177,90 @@ public class AsyncControllerTransactionTimingTest extends HTTP2TestBase {
           .as("%s: '%s' was reported with %s ms", kind, sample.getSampleLabel(), sample.getTime())
           .isNotNegative();
     }
+  }
+
+  /**
+   * A scheduled end that falls while the requests are on the wire must not throw their responses
+   * away. A stock sampler never loses one: {@code stopSchedulerIfNeeded} runs after the sample
+   * returns, so a request that is already out always finishes and is reported, and its transaction
+   * closes with it inside. This controller keeps its requests out across turns, so without holding
+   * the deadline off the thread stopped between them - the responses were dropped and the
+   * transaction was reported empty, at 0 ms.
+   */
+  @Test
+  public void t5RequestsAlreadyOnTheWireMustSurviveTheScheduledEnd() {
+    TreeShape shape = fixture -> new AsyncScenarioRunner.Node[]{
+        node(fixture.controller("controller"),
+            node(fixture.http("S1", LATENCY)),
+            node(fixture.http("S2", LATENCY)))
+    };
+    // The end lands after the requests went out and well before they come back.
+    Result actual = execute(ControllerKind.ASYNC_PARENT, 1, shape,
+        AsyncScenarioRunner.schedulerEndingIn(LATENCY / 4));
+    SampleResult parent = actual.topLevelResult("controller");
+    report("T5 scheduled end falls mid-flight", actual, parent);
+
+    SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(actual.hung()).as("the thread must still stop, not outlive its schedule")
+        .isFalse();
+    softly.assertThat(parent).as("a parent sample must be reported").isNotNull();
+    if (parent != null) {
+      softly.assertThat(labelsOf(children(parent)))
+          .as("both responses were already on their way back, so both must be reported")
+          .containsExactly("S1", "S2");
+      softly.assertThat(parent.getTime())
+          .as("and the transaction must measure them, not come out as an empty 0 ms row")
+          .isGreaterThanOrEqualTo(LATENCY);
+    }
+    softly.assertAll();
+  }
+
+  /**
+   * Holding the scheduled end off is for the responses this controller already asked for, not a
+   * licence to keep asking: the children it had not dispatched yet when the end went by must stay
+   * undispatched, or a duration-limited run keeps putting load on the system under test after the
+   * time it was given, and the thread outlives its schedule by a whole controller block instead of
+   * by the responses that were on the wire.
+   */
+  @Test
+  public void t6NothingNewIsDispatchedOnceTheScheduledEndHasGoneBy() {
+    TreeShape shape = fixture -> new AsyncScenarioRunner.Node[]{
+        node(fixture.controller("controller"),
+            node(fixture.http("S1", LATENCY)),
+            node(fixture.http("S2", LATENCY)),
+            node(fixture.http("S3", LATENCY)),
+            node(fixture.http("S4", LATENCY)),
+            node(fixture.http("S5", LATENCY)))
+    };
+    // Over by the time the controller gets its second turn, whatever the machine's speed: dispatches
+    // cost microseconds, so a scheduled end a few milliseconds out is a race the test would lose.
+    Result actual = execute(ControllerKind.ASYNC_PARENT, 1, shape,
+        AsyncScenarioRunner.expiredScheduler());
+    SampleResult parent = actual.topLevelResult("controller");
+    report("T6 scheduled end falls after the first dispatches", actual, parent);
+    System.out.println("  dispatched: " + actual.dispatchOrder());
+
+    SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(actual.hung()).as("the thread must still stop").isFalse();
+    softly.assertThat(parent).as("a parent sample must be reported").isNotNull();
+    if (parent != null) {
+      softly.assertThat(labelsOf(children(parent)))
+          .as("the request that did go out must still be collected and reported")
+          .containsExactlyElementsOf(actual.dispatchOrder());
+      softly.assertThat(actual.dispatchOrder())
+          .as("the run was already over on the controller's second turn, so only the request that "
+              + "was on the wire by then may exist")
+          .containsExactly("S1");
+    }
+    softly.assertAll();
+  }
+
+  private static List<String> labelsOf(List<SampleResult> results) {
+    List<String> labels = new ArrayList<>();
+    for (SampleResult result : results) {
+      labels.add(result.getSampleLabel());
+    }
+    return labels;
   }
 
   /** Mirrors issue #155's test plan: parent sample on, think time excluded. */

--- a/src/test/java/com/blazemeter/jmeter/http2/control/async/AsyncScenarioRunner.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/control/async/AsyncScenarioRunner.java
@@ -167,9 +167,40 @@ public final class AsyncScenarioRunner {
    * child result at all yet.
    */
   public static Consumer<JMeterThread> expiredScheduler() {
+    return schedulerEndingIn(-1);
+  }
+
+  /**
+   * Thread Group scheduler whose end lands {@code millisFromNow} from the start of the run, so it
+   * can be made to fall while requests are still on the wire - which for this controller is most of
+   * the time, since its requests live across turns rather than inside one.
+   */
+  public static Consumer<JMeterThread> schedulerEndingIn(long millisFromNow) {
     return thread -> {
       thread.setScheduled(true);
-      thread.setEndTime(System.currentTimeMillis() - 1);
+      thread.setEndTime(System.currentTimeMillis() + millisFromNow);
+    };
+  }
+
+  /**
+   * Stops the thread from the outside {@code millisFromNow} into the run, the way the Stop button
+   * and {@code StandardJMeterEngine} do: straight onto the running flag, with no scheduled end
+   * involved. Nothing a controller does can hold that off, so whatever it had on the wire at that
+   * moment is lost - which is the situation the reported sample still has to survive.
+   */
+  public static Consumer<JMeterThread> stopAfter(long millisFromNow) {
+    return thread -> {
+      Thread stopper = new Thread(() -> {
+        try {
+          Thread.sleep(millisFromNow);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+        thread.stop();
+      }, "scenario-stopper");
+      stopper.setDaemon(true);
+      stopper.start();
     };
   }
 

--- a/src/test/java/com/blazemeter/jmeter/http2/control/async/AsyncScenarioRunner.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/control/async/AsyncScenarioRunner.java
@@ -5,6 +5,7 @@ import com.blazemeter.jmeter.http2.sampler.JMeterTestUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 import org.apache.jmeter.control.LoopController;
 import org.apache.jmeter.control.TransactionController;
 import org.apache.jmeter.engine.StandardJMeterEngine;
@@ -157,7 +158,32 @@ public final class AsyncScenarioRunner {
     return run(group, DEFAULT_TIMEOUT_MILLIS, children);
   }
 
+  /**
+   * Thread Group scheduler that has already run out. The first {@code stopSchedulerIfNeeded()} call
+   * inside {@code JMeterThread.processSampler} then clears the running flag, so the run is cut
+   * short right after the first sampler was handed out — which is what a duration-limited test
+   * (or a manual Stop) does to whatever transaction happens to be open at that moment. With the
+   * async controller that moment is a dispatch turn, so the open transaction has collected no
+   * child result at all yet.
+   */
+  public static Consumer<JMeterThread> expiredScheduler() {
+    return thread -> {
+      thread.setScheduled(true);
+      thread.setEndTime(System.currentTimeMillis() - 1);
+    };
+  }
+
   public static Outcome run(ThreadGroup group, long timeoutMillis, Node... children) {
+    return run(group, timeoutMillis, thread -> {
+    }, children);
+  }
+
+  /**
+   * @param threadSetup applied to the {@link JMeterThread} just before it is started, for the
+   *     settings a Thread Group normally pushes onto it (scheduler, start/end time)
+   */
+  public static Outcome run(ThreadGroup group, long timeoutMillis,
+                            Consumer<JMeterThread> threadSetup, Node... children) {
     JMeterTestUtils.setupJmeterEnv();
     ListedHashTree tree = new ListedHashTree();
     HashTree groupTree = tree.add(group);
@@ -178,6 +204,7 @@ public final class AsyncScenarioRunner {
     jmeterThread.setOnErrorStopTestNow(group.getOnErrorStopTestNow());
     jmeterThread.setOnErrorStopThread(group.getOnErrorStopThread());
     jmeterThread.setOnErrorStartNextLoop(group.getOnErrorStartNextLoop());
+    threadSetup.accept(jmeterThread);
 
     Thread runner = new Thread(jmeterThread, group.getName() + " 1-1");
     runner.setDaemon(true);

--- a/src/test/java/com/blazemeter/jmeter/http2/control/async/CountingTimer.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/control/async/CountingTimer.java
@@ -33,6 +33,10 @@ public class CountingTimer extends AbstractTestElement implements Timer {
     this.delayMillis = delayMillis;
   }
 
+  public void setDelay(long delayMillis) {
+    this.delayMillis = delayMillis;
+  }
+
   @Override
   public long delay() {
     invocations.incrementAndGet();

--- a/src/test/java/com/blazemeter/jmeter/http2/control/async/EmbeddedResourceDrainLoopTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/control/async/EmbeddedResourceDrainLoopTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import com.blazemeter.jmeter.http2.HTTP2TestBase;
 import com.blazemeter.jmeter.http2.core.HTTP2FutureResponseListener;
 import com.blazemeter.jmeter.http2.core.HTTP2JettyClient;
+import com.blazemeter.jmeter.http2.core.SampleClock;
 import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
 import java.io.Closeable;
 import java.io.IOException;
@@ -182,10 +183,14 @@ public class EmbeddedResourceDrainLoopTest extends HTTP2TestBase {
         .as("timed-out child must report the wait until give-up, not a ~0ms sampleStart/sampleEnd "
             + "pair; that elapsed end time is what pushes the parent container's clock forward")
         .isGreaterThanOrEqualTo(RESPONSE_TIMEOUT_MILLIS);
+    // On the container's own clock, the way addSubResult itself compares the two (Bug 51855):
+    // each SampleResult captures its nano offset when it is constructed, so two results built on
+    // either side of a refresh of that offset are a millisecond apart on the raw stamps alone.
     assertThat(container.getEndTime())
         .as("parent end time must advance to cover the embedded timeout wait (addSubResult takes "
             + "max of child end times)")
-        .isGreaterThanOrEqualTo(timedOutChild.getEndTime());
+        .isGreaterThanOrEqualTo(
+            SampleClock.fromResultClock(container, timedOutChild, timedOutChild.getEndTime()));
     assertThat(timedOutChild.getConnectTime())
         .as("a poll-aborted attempt never completed the handshake/response, so connect stays 0 "
             + "rather than copying the parent's connect")

--- a/src/test/java/com/blazemeter/jmeter/http2/control/async/ScenarioFixture.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/control/async/ScenarioFixture.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import org.apache.jmeter.assertions.ResponseAssertion;
 import org.apache.jmeter.control.GenericController;
 import org.apache.jmeter.control.TransactionController;
@@ -297,7 +298,21 @@ public final class ScenarioFixture implements Closeable {
   }
 
   public CountingTimer timer(String name) {
-    return timers.computeIfAbsent(name, CountingTimer::new);
+    return timer(name, 0);
+  }
+
+  /**
+   * A timer that really pauses, for the scenarios where the think time has to be long enough to be
+   * told apart from the request times in the reported sample.
+   *
+   * <p>The delay is applied on every call, not only when the timer is created: a scenario that asks
+   * for the same name twice used to keep whichever delay came first, so a test asserting on a think
+   * time could silently run with none and pass without measuring anything.
+   */
+  public CountingTimer timer(String name, long delayMillis) {
+    CountingTimer timer = timers.computeIfAbsent(name, CountingTimer::new);
+    timer.setDelay(delayMillis);
+    return timer;
   }
 
   public CountingPreProcessor pre(String name) {
@@ -356,6 +371,14 @@ public final class ScenarioFixture implements Closeable {
   public Result run(ThreadGroup group, long timeoutMillis,
                     AsyncScenarioRunner.Node... children) {
     return new Result(this, AsyncScenarioRunner.run(group, timeoutMillis, children));
+  }
+
+  /** @see AsyncScenarioRunner#run(ThreadGroup, long, Consumer, AsyncScenarioRunner.Node...) */
+  public Result run(ThreadGroup group, long timeoutMillis,
+                    Consumer<org.apache.jmeter.threads.JMeterThread> threadSetup,
+                    AsyncScenarioRunner.Node... children) {
+    return new Result(this,
+        AsyncScenarioRunner.run(group, timeoutMillis, threadSetup, children));
   }
 
   @Override

--- a/src/test/java/com/blazemeter/jmeter/http2/control/async/StubAsyncTransport.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/control/async/StubAsyncTransport.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import com.blazemeter.jmeter.http2.core.HTTP2FutureResponseListener;
 import com.blazemeter.jmeter.http2.core.HTTP2JettyClient;
+import com.blazemeter.jmeter.http2.core.SampleClock;
 import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
 import java.io.Closeable;
 import java.net.ConnectException;
@@ -256,11 +257,15 @@ public final class StubAsyncTransport implements Closeable {
       throw new TimeoutException("stub transport: no response for " + sampler.getName());
     }
     ResponseSpec spec = spec(sampler.getName());
-    long start = listener.getResponseStart() > 0
-        ? listener.getResponseStart()
-        : System.currentTimeMillis();
-    long end = listener.getResponseEnd() > start ? listener.getResponseEnd() : start + 1;
-    return fill(result, spec, start, end);
+    // On this result's own clock, like the real client: a SampleResult keeps a nano-derived clock of
+    // its own by default, so stamping children with System.currentTimeMillis() readings would put
+    // every child's times a clock offset away from the transaction's. See SampleClock.
+    long start = listener.getResponseStartOn(result);
+    if (start <= 0) {
+      start = result.currentTimeInMillis();
+    }
+    long end = listener.getResponseEndOn(result);
+    return fill(result, spec, start, Math.max(start + 1, end));
   }
 
   private HTTPSampleResult onSyncSample(HTTP2Sampler sampler, HTTPSampleResult result)
@@ -269,17 +274,17 @@ public final class StubAsyncTransport implements Closeable {
     ResponseSpec spec = spec(name);
     syncSampled.add(name);
     trackInFlight(1);
-    long start = System.currentTimeMillis();
+    long start = result.currentTimeInMillis();
     if (spec.latencyMillis > 0) {
       Thread.sleep(spec.latencyMillis);
     }
     trackInFlight(-1);
-    return fill(result, spec, start, Math.max(start + 1, System.currentTimeMillis()));
+    return fill(result, spec, start, Math.max(start + 1, result.currentTimeInMillis()));
   }
 
   private HTTPSampleResult fill(HTTPSampleResult result, ResponseSpec spec, long start, long end) {
     if (result.getStartTime() == 0 && result.getEndTime() == 0) {
-      result.setStampAndTime(start, Math.max(1, end - start));
+      SampleClock.stampInterval(result, start, Math.max(1, end - start));
     }
     result.setResponseCode(spec.responseCode);
     result.setResponseMessage(spec.responseMessage);
@@ -293,7 +298,7 @@ public final class StubAsyncTransport implements Closeable {
     for (String resource : spec.embeddedResources) {
       HTTPSampleResult sub = new HTTPSampleResult();
       sub.setSampleLabel(resource);
-      sub.setStampAndTime(start, 1);
+      SampleClock.stampInterval(sub, start, 1);
       sub.setResponseCodeOK();
       sub.setResponseMessage("OK");
       sub.setSuccessful(true);

--- a/src/test/java/com/blazemeter/jmeter/http2/core/AlpnAbsentHttp2RejectedTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/AlpnAbsentHttp2RejectedTest.java
@@ -1,0 +1,170 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.SERVER_PATH_200;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.URL;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.ssl.SslConnection;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Reproduction of a failure that needs two conditions at once, which is why it only shows up in
+ * networks that have both. Each is simulated here.
+ *
+ * <p><b>The peer.</b> {@code withSSL()} without {@code withALPN()} terminates TLS and hands
+ * straight to HTTP/1.1, so no ALPN protocol is ever selected - the shape a TLS-inspecting egress
+ * produces, and one that RFC 7301 permits, since a server "MAY return a suitable protocol
+ * selection response". Jetty then picks the first configured protocol, HTTP/2, and the preface is
+ * answered with HTTP/1.1 bytes, which our parser rejects with {@code FRAME_SIZE_ERROR}.
+ *
+ * <p><b>The address list.</b> A host that resolves to reachable addresses followed by unreachable
+ * ones. Binding the server to {@code 127.0.0.1} only, and sampling {@code localhost}, reproduces
+ * it: the first address works at the socket level and dies at the HTTP/2 preface, and the next one
+ * fails outright - so the failure that survives Jetty's connect loop is the second one, and the
+ * perfectly usable first address is never reported.
+ *
+ * <p>That second condition is what makes this fail rather than merely be slow. With a single
+ * address the plugin's HTTP/1.1 fallback rescues the sample after one wasted connection, which is
+ * why the defect stays invisible on an ordinary dual-stack host with working connectivity.
+ */
+public class AlpnAbsentHttp2RejectedTest extends HTTP2TestBase {
+
+  /** One entry per TCP connection the server accepted: an SslConnection is created per socket. */
+  private final List<String> accepted = new CopyOnWriteArrayList<>();
+
+  private TeardownableServer server;
+  private HTTP2JettyClient client;
+  private int port;
+
+  @Before
+  public void setUp() throws Exception {
+    HTTP2JettyClientTestIsolation.resetSharedClientState();
+    // Only the IPv4 loopback listens, so the other address localhost resolves to fails to connect,
+    // standing in for an address family the network has no route for.
+    server = buildServer("127.0.0.1");
+    server.start();
+    port = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (client != null) {
+      client.stop();
+    }
+    if (server != null && server.isStarted()) {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void samplesSuccessfullyThroughTheAddressThatWorks() throws Exception {
+    InetAddress[] addresses = InetAddress.getAllByName("localhost");
+    assumeTrue("localhost resolves to a single address here, so there is no roll-over to lose it",
+        addresses.length > 1);
+    assumeTrue("this reproduction needs IPv4 to be tried first, as the JDK default does",
+        addresses[0] instanceof Inet4Address);
+
+    client = new HTTP2JettyClient(false, "alpn-absent-multi-address");
+    client.start();
+
+    HTTPSampleResult result = sample();
+
+    assertThat(result.isSuccessful())
+        .as("127.0.0.1 serves this fine over HTTP/1.1; only the HTTP/2 attempt against it failed, "
+            + "and that must not turn into a failed sample because a later address is unreachable")
+        .isTrue();
+    assertThat(result.getResponseCode()).isEqualTo("200");
+  }
+
+  @Test
+  public void remembersTheOriginSoLaterSamplesDoNotRetryHttp2() throws Exception {
+    // The first sample pays one rejected HTTP/2 attempt per usable address; the point of
+    // remembering the origin is that no later sample pays it again. Counted server side, where a
+    // rejected attempt is an extra accepted connection.
+    client = new HTTP2JettyClient(false, "alpn-absent-remembered");
+    client.start();
+    sample();
+    int afterFirst = accepted.size();
+
+    sample();
+
+    assertThat(accepted.size() - afterFirst)
+        .as("the second sample must not open more connections than the one it needs")
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void stopsReOfferingHttp2ToTheRemainingAddressesOfTheSameRequest() throws Exception {
+    InetAddress[] addresses = InetAddress.getAllByName("localhost");
+    assumeTrue("needs more than one usable address to have a roll-over worth shortening",
+        addresses.length > 1);
+    // This server listens on every address localhost resolves to, so each one is usable and each
+    // one would otherwise be offered HTTP/2 and refuse it in turn.
+    server.stop();
+    accepted.clear();
+    server = buildServer(null);
+    server.start();
+    port = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+    client = new HTTP2JettyClient(false, "alpn-absent-rollover");
+    client.start();
+
+    HTTPSampleResult result = sample();
+
+    assertThat(result.isSuccessful()).isTrue();
+    assertThat(accepted.size())
+        .as("one refused HTTP/2 attempt is unavoidable before the origin is known; paying it "
+            + "again on every remaining address is not")
+        .isEqualTo(2);
+  }
+
+  private TeardownableServer buildServer(String host) {
+    TeardownableServer built = new ServerBuilder().withSSL().withHTTP1().buildServer();
+    ServerConnector connector = (ServerConnector) built.getConnectors()[0];
+    if (host != null) {
+      connector.setHost(host);
+    }
+    connector.addBean(new Connection.Listener() {
+      @Override
+      public void onOpened(Connection connection) {
+        if (connection instanceof SslConnection) {
+          accepted.add(connection.toString());
+        }
+      }
+
+      @Override
+      public void onClosed(Connection connection) {
+        // Only the accepted count matters here.
+      }
+    });
+    return built;
+  }
+
+  private HTTPSampleResult sample() throws Exception {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.GET);
+    sampler.setDomain("localhost");
+    sampler.setProtocol(HTTPConstants.PROTOCOL_HTTPS);
+    sampler.setPort(port);
+    sampler.setPath(SERVER_PATH_200);
+
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setSampleLabel("GET_ALPN_ABSENT_MULTI_ADDRESS");
+    result.setHTTPMethod(HTTPConstants.GET);
+    result.setURL(new URL(HTTPConstants.PROTOCOL_HTTPS, "localhost", port, SERVER_PATH_200));
+    return client.sample(sampler, result, false, 0);
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/AuthBasicDigestMechanismTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/AuthBasicDigestMechanismTest.java
@@ -1,0 +1,234 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.AUTH_PASSWORD;
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.AUTH_REALM;
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.AUTH_USERNAME;
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.HOST_NAME;
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.SERVER_PATH_200;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import com.blazemeter.jmeter.http2.sampler.JMeterTestUtils;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.jmeter.protocol.http.control.AuthManager;
+import org.apache.jmeter.protocol.http.control.AuthManager.Mechanism;
+import org.apache.jmeter.protocol.http.control.Authorization;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.util.JMeterUtils;
+import org.eclipse.jetty.client.AbstractAuthentication;
+import org.eclipse.jetty.client.Authentication;
+import org.eclipse.jetty.client.AuthenticationStore;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * {@code BASIC_DIGEST} is deprecated in JMeter but still selectable and still present in older
+ * plans, and {@code HTTPHC4Impl} keeps honouring it: the credentials are registered without being
+ * bound to a scheme, so they answer either challenge. This plugin used to drop those rows in
+ * {@code isSupportedMechanism} without a word, leaving the plan silently unauthenticated.
+ *
+ * <p>Jetty binds an {@code Authentication} to one challenge type, so a single {@code BASIC_DIGEST}
+ * row has to become two registrations - which is what these tests pin, along with the dedup that
+ * keeps them from piling up per sample.
+ */
+public class AuthBasicDigestMechanismTest extends HTTP2TestBase {
+
+  private static final String PREEMPTIVE_PROPERTY = "httpJettyClient.auth.preemptive";
+
+  private String originalPreemptiveProperty;
+  private TeardownableServer server;
+  private HTTP2JettyClient client;
+
+  @BeforeClass
+  public static void setupClass() {
+    JMeterTestUtils.setupJmeterEnv();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    originalPreemptiveProperty = JMeterUtils.getProperty(PREEMPTIVE_PROPERTY);
+    // Registering Jetty Authentications is the reactive path; preemptive mode registers Results
+    // instead and another test may have left the shared property on.
+    JMeterUtils.setProperty(PREEMPTIVE_PROPERTY, "false");
+    HTTP2JettyClientTestIsolation.resetSharedClientState();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (client != null) {
+      client.stop();
+    }
+    if (server != null && server.isStarted()) {
+      server.stop();
+    }
+    if (originalPreemptiveProperty == null) {
+      JMeterUtils.getJMeterProperties().remove(PREEMPTIVE_PROPERTY);
+    } else {
+      JMeterUtils.setProperty(PREEMPTIVE_PROPERTY, originalPreemptiveProperty);
+    }
+  }
+
+  @Test
+  public void authenticatesAgainstABasicServerWithABasicDigestRow() throws Exception {
+    int port = startAuthServer(new ServerBuilder().withHTTP1().withSSL().withBasicAuth());
+    HTTP2Sampler sampler = samplerWith(Mechanism.BASIC_DIGEST, port);
+
+    HTTPSampleResult result = sample(sampler);
+
+    assertThat(result.isSuccessful()).isTrue();
+    assertThat(result.getResponseCode()).isEqualTo("200");
+  }
+
+  @Test
+  public void authenticatesAgainstADigestServerWithABasicDigestRow() throws Exception {
+    int port = startAuthServer(new ServerBuilder().withHTTP1().withSSL().withDigestAuth());
+    HTTP2Sampler sampler = samplerWith(Mechanism.BASIC_DIGEST, port);
+
+    HTTPSampleResult result = sample(sampler);
+
+    assertThat(result.isSuccessful()).isTrue();
+    assertThat(result.getResponseCode()).isEqualTo("200");
+  }
+
+  @Test
+  public void registersOneBasicAndOneDigestAuthenticationForABasicDigestRow() throws Exception {
+    int port = startAuthServer(new ServerBuilder().withHTTP1().withSSL().withBasicAuth());
+    HTTP2Sampler sampler = samplerWith(Mechanism.BASIC_DIGEST, port);
+
+    sample(sampler);
+
+    assertThat(authenticationTypes()).containsExactlyInAnyOrder("Basic", "Digest");
+  }
+
+  @Test
+  public void registersOnlyTheMatchingAuthenticationForASingleMechanismRow() throws Exception {
+    int port = startAuthServer(new ServerBuilder().withHTTP1().withSSL().withBasicAuth());
+    HTTP2Sampler sampler = samplerWith(Mechanism.BASIC, port);
+
+    sample(sampler);
+
+    assertThat(authenticationTypes()).containsExactly("Basic");
+  }
+
+  @Test
+  public void keepsBothRegistrationsIdempotentAcrossSamples() throws Exception {
+    int port = startAuthServer(new ServerBuilder().withHTTP1().withSSL().withBasicAuth());
+    HTTP2Sampler sampler = samplerWith(Mechanism.BASIC_DIGEST, port);
+
+    for (int i = 0; i < 5; i++) {
+      assertThat(sample(sampler).isSuccessful())
+          .as("sample %d should authenticate", i)
+          .isTrue();
+    }
+
+    assertThat(authenticationTypes()).containsExactlyInAnyOrder("Basic", "Digest");
+  }
+
+  @Test
+  public void sendsThePreemptiveBasicHeaderForABasicDigestRow() throws Exception {
+    JMeterUtils.setProperty(PREEMPTIVE_PROPERTY, "true");
+    client = new HTTP2JettyClient(false, "auth-basic-digest-preemptive", http1OnlyProfile());
+    client.start();
+    URL url = new URL(HTTPConstants.PROTOCOL_HTTPS, HOST_NAME, 8443, SERVER_PATH_200);
+    HttpClient probeClient = http1OnlyClient(client);
+    Request request = probeClient.newRequest(URI.create(url.toString()));
+
+    invokePreemptiveHeader(client, request, url, authManagerWith(Mechanism.BASIC_DIGEST, url));
+
+    assertThat(request.getHeaders().get(HttpHeader.AUTHORIZATION)).startsWith("Basic ");
+  }
+
+  private int startAuthServer(ServerBuilder builder) throws Exception {
+    server = builder.buildServer();
+    server.start();
+    return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+  }
+
+  private HTTP2Sampler samplerWith(Mechanism mechanism, int port) throws Exception {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.GET);
+    sampler.setDomain(HOST_NAME);
+    sampler.setProtocol(HTTPConstants.PROTOCOL_HTTPS);
+    sampler.setPort(port);
+    sampler.setPath(SERVER_PATH_200);
+    sampler.setAuthManager(authManagerWith(mechanism,
+        new URL(HTTPConstants.PROTOCOL_HTTPS, HOST_NAME, port, SERVER_PATH_200)));
+    return sampler;
+  }
+
+  private AuthManager authManagerWith(Mechanism mechanism, URL url) {
+    Authorization authorization = new Authorization();
+    authorization.setURL(url.toString());
+    authorization.setUser(AUTH_USERNAME);
+    authorization.setPass(AUTH_PASSWORD);
+    authorization.setRealm(AUTH_REALM);
+    authorization.setMechanism(mechanism);
+    AuthManager authManager = new AuthManager();
+    authManager.addAuth(authorization);
+    return authManager;
+  }
+
+  private HTTPSampleResult sample(HTTP2Sampler sampler) throws Exception {
+    if (client == null) {
+      client = new HTTP2JettyClient(false, "auth-basic-digest", http1OnlyProfile());
+      client.start();
+    }
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setURL(sampler.getUrl());
+    result.setHTTPMethod(sampler.getMethod());
+    return client.sample(sampler, result, false, 0);
+  }
+
+  private List<String> authenticationTypes() throws Exception {
+    return registeredAuthentications(http1OnlyClient(client)).stream()
+        .map(authentication -> ((AbstractAuthentication) authentication).getType())
+        .collect(Collectors.toList());
+  }
+
+  private static HTTP2ClientProfileConfig http1OnlyProfile() {
+    // The auth servers here speak HTTP/1.1 only; racing HTTP/3 would just burn the samples.
+    return HTTP2ClientProfileConfig.builder()
+        .enableHttp1(true)
+        .enableHttp2(false)
+        .enableHttp3(false)
+        .build();
+  }
+
+  private static HttpClient http1OnlyClient(HTTP2JettyClient client) throws Exception {
+    Field field = HTTP2JettyClient.class.getDeclaredField("httpClientHttp1Only");
+    field.setAccessible(true);
+    return (HttpClient) field.get(client);
+  }
+
+  private static List<Authentication> registeredAuthentications(HttpClient httpClient)
+      throws Exception {
+    AuthenticationStore store = httpClient.getAuthenticationStore();
+    Field field = store.getClass().getDeclaredField("authentications");
+    field.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    List<Authentication> authentications = (List<Authentication>) field.get(store);
+    return authentications;
+  }
+
+  private static void invokePreemptiveHeader(HTTP2JettyClient client, Request request, URL url,
+                                             AuthManager authManager) throws Exception {
+    Method method = HTTP2JettyClient.class.getDeclaredMethod("addPreemptiveAuthorizationHeader",
+        Request.class, URL.class, AuthManager.class);
+    method.setAccessible(true);
+    method.invoke(client, request, url, authManager);
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/CleartextBodyClientSelectionTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/CleartextBodyClientSelectionTest.java
@@ -1,0 +1,129 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.junit.Assert.assertSame;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import com.blazemeter.jmeter.http2.sampler.JMeterTestUtils;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URI;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Pins which client a bodied cleartext request gets.
+ *
+ * <p>Such requests are diverted to the HTTP/1.1-only client to sidestep the h2c Upgrade dance,
+ * whose first request travels as plain HTTP/1.1 and which servers handle inconsistently when it
+ * carries a body. That is a shortcut around a negotiation, not a protocol choice, so it must not
+ * survive where HTTP/1.1 is disabled or where h2c is spoken from the first byte anyway — issue
+ * #157, where POSTs to an h2c-only endpoint went out as HTTP/1.1 and the server's HTTP/2 frames
+ * came back through the HTTP/1.1 parser as {@code Illegal character CNTL=0x0}.
+ */
+public class CleartextBodyClientSelectionTest extends HTTP2TestBase {
+
+  private static final URI CLEARTEXT_URI = URI.create("http://h2c-only.example.com:8000/policies");
+
+  private HTTP2JettyClient client;
+
+  @BeforeClass
+  public static void setupClass() {
+    JMeterTestUtils.setupJmeterEnv();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    HTTP2JettyClient.clearStaticProtocolCaches();
+    client = new HTTP2JettyClient();
+    setBoolean("enableHttp1", true);
+    setBoolean("enableHttp2", true);
+    setBoolean("enableHttp3", false);
+    setBoolean("http1UpgradeRequired", false);
+    setBoolean("http2PriorKnowledgeEnabled", false);
+    setBoolean("http3PriorKnowledgeEnabled", false);
+    setBoolean("h2cCacheEnabled", false);
+  }
+
+  @Test
+  public void shouldUseHttp1OnlyForCleartextPostWhenUpgradeIsTheAlternative() throws Exception {
+    setBoolean("http1UpgradeRequired", true);
+
+    assertSame("a bodied cleartext POST must skip the h2c Upgrade dance",
+        field("httpClientHttp1Only"), resolveClientForRequest(post()));
+  }
+
+  @Test
+  public void shouldNotUseHttp1OnlyForCleartextPostWhenHttp1IsDisabled() throws Exception {
+    setBoolean("enableHttp1", false);
+    setBoolean("http1UpgradeRequired", true);
+
+    assertSame("with HTTP/1.1 disabled a bodied POST must still be spoken as h2c",
+        field("httpClientH2cPrior"), resolveClientForRequest(post()));
+  }
+
+  @Test
+  public void shouldNotUseHttp1OnlyForCleartextPostWithH2cPriorKnowledge() throws Exception {
+    setBoolean("http2PriorKnowledgeEnabled", true);
+
+    assertSame("prior knowledge means there is no Upgrade to avoid",
+        field("httpClientH2cPrior"), resolveClientForRequest(post()));
+  }
+
+  @Test
+  public void shouldUseHttp1OnlyForCleartextGetSendingParametersAsBody() throws Exception {
+    setBoolean("http1UpgradeRequired", true);
+    HTTP2Sampler sampler = sampler(HTTPConstants.GET);
+    sampler.setPostBodyRaw(true);
+
+    assertSame(field("httpClientHttp1Only"),
+        resolveClientForRequest(sampler, result(HTTPConstants.GET)));
+  }
+
+  private HTTP2Sampler post() {
+    HTTP2Sampler sampler = sampler(HTTPConstants.POST);
+    sampler.addArgument("policy", "value");
+    return sampler;
+  }
+
+  private HTTP2Sampler sampler(String method) {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(method);
+    return sampler;
+  }
+
+  private HTTPSampleResult result(String method) throws Exception {
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setURL(CLEARTEXT_URI.toURL());
+    result.setHTTPMethod(method);
+    return result;
+  }
+
+  private Object resolveClientForRequest(HTTP2Sampler sampler) throws Exception {
+    return resolveClientForRequest(sampler, result(HTTPConstants.POST));
+  }
+
+  private Object resolveClientForRequest(HTTP2Sampler sampler, HTTPSampleResult result)
+      throws Exception {
+    Method m = HTTP2JettyClient.class.getDeclaredMethod(
+        "resolveClientForRequest", HTTP2Sampler.class, HTTPSampleResult.class);
+    m.setAccessible(true);
+    return m.invoke(client, sampler, result);
+  }
+
+  private Object field(String name) throws Exception {
+    Field f = HTTP2JettyClient.class.getDeclaredField(name);
+    f.setAccessible(true);
+    return f.get(client);
+  }
+
+  private void setBoolean(String name, boolean value) throws Exception {
+    Field f = HTTP2JettyClient.class.getDeclaredField(name);
+    f.setAccessible(true);
+    f.setBoolean(client, value);
+  }
+
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/ConnectAttemptRecorderTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/ConnectAttemptRecorderTest.java
@@ -1,0 +1,277 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+import java.net.URL;
+import java.nio.channels.ClosedChannelException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import javax.net.ssl.SSLHandshakeException;
+import org.eclipse.jetty.client.Connection;
+import org.eclipse.jetty.util.Promise;
+import org.junit.Test;
+
+/**
+ * Jetty keeps only the last address's failure when it walks the resolved addresses of a host, so
+ * on a dual-stack origin the IPv4 error - normally the interesting one, since the JDK tries it
+ * first - disappears. This pins the bookkeeping that gets it back: what the recorder captures when
+ * it wraps the per-address promise, which attempts belong to a given sample, and that wrapping the
+ * promise does not disturb the roll-over it is listening to.
+ */
+public class ConnectAttemptRecorderTest {
+
+  private static final long EVERYTHING = 0;
+
+  @Test
+  public void attachesEveryFailureRecordedForTheSampledOrigin() throws Exception {
+    ConnectAttemptRecorder recorder = new ConnectAttemptRecorder();
+    failAttempt(recorder, address("127.0.0.1", 8443),
+        new ConnectException("Connection refused: connect"));
+    failAttempt(recorder, address("::1", 8443),
+        new SocketException("Network is unreachable: connect"));
+    Throwable reported = new ConnectException("Connection refused: connect");
+
+    recorder.attachTo(reported, new URL("https://localhost:8443/x"), EVERYTHING);
+
+    assertThat(suppressedMessages(reported)).containsExactly(
+        "Connect to localhost/127.0.0.1:8443 failed",
+        "Connect to localhost/0:0:0:0:0:0:0:1:8443 failed");
+  }
+
+  @Test
+  public void keepsTheOriginalFailureAsTheCauseOfEachAttempt() throws Exception {
+    ConnectAttemptRecorder recorder = new ConnectAttemptRecorder();
+    IOException original = new ConnectException("Connection refused: connect");
+    failAttempt(recorder, address("127.0.0.1", 8443), original);
+    Throwable reported = new ConnectException("boom");
+
+    recorder.attachTo(reported, new URL("https://localhost:8443/x"), EVERYTHING);
+
+    assertThat(reported.getSuppressed()[0].getCause()).isSameAs(original);
+  }
+
+  @Test
+  public void namesTheStageEachAttemptDiedAt() throws Exception {
+    // One wrapper covers all three because they all fail the same per-address promise: the socket,
+    // the TLS handshake, and - after TLS already succeeded - the HTTP/2 preface.
+    ConnectAttemptRecorder recorder = new ConnectAttemptRecorder();
+    failAttempt(recorder, address("127.0.0.1", 8443), new ConnectException("refused"));
+    failAttempt(recorder, address("127.0.0.1", 8443), new SSLHandshakeException("bad cert"));
+    failAttempt(recorder, address("127.0.0.1", 8443), new ClosedChannelException());
+    Throwable reported = new ConnectException("boom");
+
+    recorder.attachTo(reported, new URL("https://localhost:8443/x"), EVERYTHING);
+
+    assertThat(suppressedMessages(reported)).containsExactly(
+        "Connect to localhost/127.0.0.1:8443 failed",
+        "TLS handshake with localhost/127.0.0.1:8443 failed",
+        "Connection to localhost/127.0.0.1:8443 failed");
+  }
+
+  @Test
+  public void leavesTheWrappedPromiseDrivingTheRollOver() throws Exception {
+    // The wrapped promise is what makes Jetty try the next address. Swallowing either outcome
+    // here would turn a diagnostic into a hang or a lost connection.
+    ConnectAttemptRecorder recorder = new ConnectAttemptRecorder();
+    AtomicReference<Throwable> delegatedFailure = new AtomicReference<>();
+    AtomicReference<Connection> delegatedSuccess = new AtomicReference<>();
+    Map<String, Object> context = contextWith(new Promise<Connection>() {
+      @Override
+      public void succeeded(Connection result) {
+        delegatedSuccess.set(result);
+      }
+
+      @Override
+      public void failed(Throwable failure) {
+        delegatedFailure.set(failure);
+      }
+    });
+    recorder.instrument(address("127.0.0.1", 8443), context);
+    ConnectException failure = new ConnectException("refused");
+
+    promiseIn(context).succeeded(null);
+    promiseIn(context).failed(failure);
+
+    assertThat(delegatedSuccess.get()).isNull();
+    assertThat(delegatedFailure.get()).isSameAs(failure);
+  }
+
+  @Test
+  public void leavesTheContextAloneWhenThereIsNoPromiseToWrap() throws Exception {
+    ConnectAttemptRecorder recorder = new ConnectAttemptRecorder();
+    Map<String, Object> context = new HashMap<>();
+
+    recorder.instrument(address("127.0.0.1", 8443), context);
+    recorder.instrument(null, contextWith(noOpPromise()));
+
+    assertThat(context).isEmpty();
+  }
+
+  @Test
+  public void ignoresAttemptsAgainstAnotherPort() throws Exception {
+    ConnectAttemptRecorder recorder = new ConnectAttemptRecorder();
+    failAttempt(recorder, address("127.0.0.1", 9999), new ConnectException("refused"));
+    Throwable reported = new ConnectException("boom");
+
+    recorder.attachTo(reported, new URL("https://localhost:8443/x"), EVERYTHING);
+
+    assertThat(reported.getSuppressed()).isEmpty();
+  }
+
+  @Test
+  public void ignoresAttemptsAgainstAnotherHost() throws Exception {
+    ConnectAttemptRecorder recorder = new ConnectAttemptRecorder();
+    failAttempt(recorder, address("127.0.0.1", 8443), new ConnectException("refused"));
+    Throwable reported = new ConnectException("boom");
+
+    recorder.attachTo(reported, new URL("https://elsewhere.invalid:8443/x"), EVERYTHING);
+
+    assertThat(reported.getSuppressed()).isEmpty();
+  }
+
+  @Test
+  public void ignoresAttemptsRecordedBeforeTheSampleStarted() throws Exception {
+    // Connects run on Jetty threads and concurrent embedded resources share the client, so the
+    // sample start is what keeps a neighbour's stale failure out of this result.
+    ConnectAttemptRecorder recorder = new ConnectAttemptRecorder();
+    failAttempt(recorder, address("127.0.0.1", 8443), new ConnectException("refused"));
+    Throwable reported = new ConnectException("boom");
+
+    recorder.attachTo(reported, new URL("https://localhost:8443/x"),
+        System.currentTimeMillis() + 60_000);
+
+    assertThat(reported.getSuppressed()).isEmpty();
+  }
+
+  @Test
+  public void matchesTheHostCaseInsensitively() throws Exception {
+    ConnectAttemptRecorder recorder = new ConnectAttemptRecorder();
+    failAttempt(recorder, address("127.0.0.1", 8443), new ConnectException("refused"));
+    Throwable reported = new ConnectException("boom");
+
+    recorder.attachTo(reported, new URL("https://LOCALHOST:8443/x"), EVERYTHING);
+
+    assertThat(reported.getSuppressed()).hasSize(1);
+  }
+
+  @Test
+  public void matchesTheDefaultPortOfTheScheme() throws Exception {
+    ConnectAttemptRecorder recorder = new ConnectAttemptRecorder();
+    failAttempt(recorder, address("127.0.0.1", 443), new ConnectException("refused"));
+    Throwable reported = new ConnectException("boom");
+
+    recorder.attachTo(reported, new URL("https://localhost/x"), EVERYTHING);
+
+    assertThat(reported.getSuppressed()).hasSize(1);
+  }
+
+  @Test
+  public void skipsTheAttemptThatIsAlreadyTheReportedCause() throws Exception {
+    // Re-attaching it would make printStackTrace emit a "[CIRCULAR REFERENCE]" marker in place of
+    // the failure. Only the discarded attempts are missing from the trace.
+    ConnectAttemptRecorder recorder = new ConnectAttemptRecorder();
+    ConnectException survivor = new ConnectException("refused");
+    failAttempt(recorder, address("127.0.0.1", 8443), survivor);
+    Throwable reported = new IOException("wrapper", survivor);
+
+    recorder.attachTo(reported, new URL("https://localhost:8443/x"), EVERYTHING);
+
+    assertThat(reported.getSuppressed()).isEmpty();
+  }
+
+  @Test
+  public void keepsOnlyTheMostRecentAttemptsWithinItsCapacity() throws Exception {
+    ConnectAttemptRecorder recorder = new ConnectAttemptRecorder(2);
+    for (int i = 0; i < 5; i++) {
+      failAttempt(recorder, address("127.0.0.1", 8443), new ConnectException("refused " + i));
+    }
+    Throwable reported = new ConnectException("boom");
+
+    recorder.attachTo(reported, new URL("https://localhost:8443/x"), EVERYTHING);
+
+    assertThat(suppressedCauseMessages(reported)).containsExactly("refused 3", "refused 4");
+  }
+
+  @Test
+  public void attachesAtMostEightAttemptsToKeepTheTraceReadable() throws Exception {
+    ConnectAttemptRecorder recorder = new ConnectAttemptRecorder();
+    for (int i = 0; i < 20; i++) {
+      failAttempt(recorder, address("127.0.0.1", 8443), new ConnectException("refused " + i));
+    }
+    Throwable reported = new ConnectException("boom");
+
+    recorder.attachTo(reported, new URL("https://localhost:8443/x"), EVERYTHING);
+
+    assertThat(reported.getSuppressed()).hasSize(8);
+    assertThat(suppressedCauseMessages(reported)).last().isEqualTo("refused 19");
+  }
+
+  @Test
+  public void toleratesMissingInputsRatherThanReplacingTheReportedFailure() throws Exception {
+    ConnectAttemptRecorder recorder = new ConnectAttemptRecorder();
+    failAttempt(recorder, address("127.0.0.1", 8443), new ConnectException("refused"));
+    Throwable reported = new ConnectException("boom");
+
+    recorder.attachTo(null, new URL("https://localhost:8443/x"), EVERYTHING);
+    recorder.attachTo(reported, null, EVERYTHING);
+
+    assertThat(reported.getSuppressed()).isEmpty();
+  }
+
+  /** Drives one address through the recorder the way Jetty's transport does. */
+  private static void failAttempt(ConnectAttemptRecorder recorder, InetSocketAddress address,
+                                  Throwable failure) {
+    Map<String, Object> context = contextWith(noOpPromise());
+    recorder.instrument(address, context);
+    promiseIn(context).failed(failure);
+  }
+
+  private static Map<String, Object> contextWith(Promise<Connection> promise) {
+    Map<String, Object> context = new HashMap<>();
+    context.put(Connection.PROMISE_CONTEXT_KEY, promise);
+    return context;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Promise<Connection> promiseIn(Map<String, Object> context) {
+    return (Promise<Connection>) context.get(Connection.PROMISE_CONTEXT_KEY);
+  }
+
+  private static Promise<Connection> noOpPromise() {
+    return new Promise<>() {
+    };
+  }
+
+  /**
+   * Mirrors how Jetty builds the address it hands to the transport: an {@code InetAddress} that
+   * still carries the name it was resolved from, so {@code getHostString()} returns that name.
+   * Built explicitly instead of resolving {@code localhost} so the test does not depend on whether
+   * this machine maps it to one address family or two.
+   */
+  private static InetSocketAddress address(String ip, int port) throws Exception {
+    InetAddress resolved =
+        InetAddress.getByAddress("localhost", InetAddress.getByName(ip).getAddress());
+    return new InetSocketAddress(resolved, port);
+  }
+
+  private static List<String> suppressedMessages(Throwable reported) {
+    return Arrays.stream(reported.getSuppressed())
+        .map(Throwable::getMessage)
+        .collect(Collectors.toList());
+  }
+
+  private static List<String> suppressedCauseMessages(Throwable reported) {
+    return Arrays.stream(reported.getSuppressed())
+        .map(suppressed -> suppressed.getCause().getMessage())
+        .collect(Collectors.toList());
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/ConnectAttemptVisibilityTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/ConnectAttemptVisibilityTest.java
@@ -1,0 +1,190 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.util.JMeterUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * The end of the thread this started from: a host that resolves to more than one address and
+ * refuses all of them used to report only the last failure, because
+ * {@code HttpClient.connect(List, int, Map)} drops the earlier ones without a log or an
+ * {@code addSuppressed}. With the JDK trying IPv4 first, that meant the IPv6 error was the only
+ * one anybody ever saw.
+ *
+ * <p>{@code localhost} is the portable way to get a multi-address origin: it maps to
+ * {@code 127.0.0.1} and, on most machines, {@code ::1} as well. The assertion is written against
+ * whatever this machine actually resolves, so it still means something where only one family is
+ * configured - it just proves more where both are.
+ *
+ * <p>The two stages covered here, a refused socket and a failed TLS handshake, share the single
+ * recovery point with the third one - a failed HTTP/2 preface. Driving that one end to end would
+ * need either a hand-rolled ALPN server that goes quiet after the handshake, or an H2C upgrade
+ * timeout to reach {@code sendWithH2cPriorKnowledge}; it is covered in
+ * {@link ConnectAttemptRecorderTest} instead.
+ */
+public class ConnectAttemptVisibilityTest extends HTTP2TestBase {
+
+  private static final String ENABLE_HTTP1 = "httpJettyClient.enableHttp1";
+  private static final String ENABLE_HTTP2 = "httpJettyClient.enableHttp2";
+  private static final String ENABLE_HTTP3 = "httpJettyClient.enableHttp3";
+
+  private final List<String[]> savedProperties = new ArrayList<>();
+
+  private HTTP2Sampler sampler;
+
+  @Before
+  public void setUp() throws Exception {
+    // Nothing is listening, so every protocol variant would just repeat the same refusals; one
+    // transport keeps the recorded attempts to the addresses actually under test.
+    overrideProperty(ENABLE_HTTP1, "true");
+    overrideProperty(ENABLE_HTTP2, "false");
+    overrideProperty(ENABLE_HTTP3, "false");
+    HTTP2JettyClientTestIsolation.resetSharedClientState();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (sampler != null) {
+      sampler.threadFinished();
+    }
+    for (String[] saved : savedProperties) {
+      if (saved[1] == null) {
+        JMeterUtils.getJMeterProperties().remove(saved[0]);
+      } else {
+        JMeterUtils.setProperty(saved[0], saved[1]);
+      }
+    }
+  }
+
+  @Test
+  public void reportsTheAttemptsJettyDiscardedNotOnlyTheLastOne() throws Exception {
+    InetAddress[] addresses = InetAddress.getAllByName("localhost");
+    assumeTrue("localhost resolves to a single address here, so nothing gets discarded",
+        addresses.length > 1);
+    int closedPort = closedPort();
+    sampler = samplerAgainst(closedPort);
+
+    SampleResult result = sampler.sample();
+
+    assertThat(result.isSuccessful()).isFalse();
+    String responseData = result.getResponseDataAsString();
+    // Jetty walks the addresses in resolution order and propagates only the last failure, so
+    // every address but the last is the one that used to vanish.
+    for (int i = 0; i < addresses.length - 1; i++) {
+      assertThat(responseData)
+          .as("the attempt against %s must be visible, not dropped by Jetty's connect loop",
+              addresses[i].getHostAddress())
+          .contains("Connect to localhost/" + addresses[i].getHostAddress() + ":" + closedPort
+              + " failed");
+    }
+  }
+
+  @Test
+  public void doesNotDuplicateTheFailureThatSurvivedJettysLoop() throws Exception {
+    sampler = samplerAgainst(closedPort());
+
+    SampleResult result = sampler.sample();
+
+    // Re-attaching the surviving attempt would make printStackTrace emit this marker instead of
+    // the failure, which is worse than what it replaced.
+    assertThat(result.getResponseDataAsString()).doesNotContain("CIRCULAR REFERENCE");
+  }
+
+  @Test
+  public void reportsTheTlsHandshakesJettyDiscardedNotOnlyTheLastOne() throws Exception {
+    InetAddress[] addresses = InetAddress.getAllByName("localhost");
+    assumeTrue("localhost resolves to a single address here, so nothing gets discarded",
+        addresses.length > 1);
+    // A plain HTTP server answering an https:// request fails the handshake deterministically:
+    // the ClientHello gets plaintext back. The socket connects first, so this is invisible to the
+    // connector's ConnectListener - it is the case the SslHandshakeListener exists for.
+    ServerBuilder.TeardownableServer server = new ServerBuilder().withHTTP1().buildServer();
+    server.start();
+    try {
+      int port = ((org.eclipse.jetty.server.ServerConnector) server.getConnectors()[0])
+          .getLocalPort();
+      sampler = samplerAgainst(port);
+      sampler.setProtocol(HTTPConstants.PROTOCOL_HTTPS);
+
+      SampleResult result = sampler.sample();
+
+      assertThat(result.isSuccessful()).isFalse();
+      String responseData = result.getResponseDataAsString();
+      for (int i = 0; i < addresses.length - 1; i++) {
+        assertThat(responseData)
+            .as("the handshake against %s must be visible, not dropped by Jetty's connect loop",
+                addresses[i].getHostAddress())
+            .contains("TLS handshake with localhost/" + addresses[i].getHostAddress() + ":" + port
+                + " failed");
+      }
+    } finally {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void keepsTheReportedFailureItselfUnchanged() throws Exception {
+    sampler = samplerAgainst(closedPort());
+
+    SampleResult result = sampler.sample();
+
+    // The attempts are added as suppressed exceptions, so the failure the sample reports - and the
+    // HttpClient4-shaped code JMeter puts in the result - must be exactly what it was before.
+    assertThat(result.getResponseCode())
+        .isEqualTo("Non HTTP response code: org.apache.http.conn.HttpHostConnectException");
+  }
+
+  @Test
+  public void attachesNothingWhenTheSampleSucceeds() throws Exception {
+    ServerBuilder.TeardownableServer server = new ServerBuilder().withHTTP1().buildServer();
+    server.start();
+    try {
+      int port = ((org.eclipse.jetty.server.ServerConnector) server.getConnectors()[0])
+          .getLocalPort();
+      sampler = samplerAgainst(port);
+      sampler.setPath(ServerBuilder.SERVER_PATH_200);
+
+      SampleResult result = sampler.sample();
+
+      assertThat(result.isSuccessful()).isTrue();
+      assertThat(result.getResponseDataAsString()).doesNotContain("Connect to localhost/");
+    } finally {
+      server.stop();
+    }
+  }
+
+  private HTTP2Sampler samplerAgainst(int port) {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.GET);
+    sampler.setDomain("localhost");
+    sampler.setPort(port);
+    sampler.setPath("/");
+    sampler.setProtocol("http");
+    return sampler;
+  }
+
+  private void overrideProperty(String key, String value) {
+    savedProperties.add(new String[] {key, JMeterUtils.getProperty(key)});
+    JMeterUtils.setProperty(key, value);
+  }
+
+  /** A port nothing is listening on: bound to learn it is free, then released. */
+  private static int closedPort() throws IOException {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
+    }
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientDnsCacheManagerTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientDnsCacheManagerTest.java
@@ -1,0 +1,191 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.http.conn.DnsResolver;
+import org.apache.jmeter.protocol.http.control.DNSCacheManager;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.SocketAddressResolver;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * A DNS Cache Manager in the plan has to reach this plugin's transport the same way it reaches
+ * {@code HTTPHC4Impl}: bound once when the per-thread client is created, applied to every protocol
+ * variant, and consulted for the host Jetty actually connects to - which under a proxy is the
+ * proxy, not the target.
+ *
+ * <p>End-to-end coverage here uses a static host entry rather than a mock DNS server. JMeter's own
+ * {@code DNSCacheManagerTest} points a mock server at an ephemeral port, which its
+ * {@code parseHostPort} makes possible only on master; on the 5.5 line this plugin targets,
+ * {@code createResolver} feeds host names straight to dnsjava's {@code ExtendedResolver} and a
+ * custom port cannot be expressed. A static host entry exercises the same integration and is the
+ * configuration load tests actually use.
+ */
+public class HTTP2JettyClientDnsCacheManagerTest extends HTTP2TestBase {
+
+  private static final String[] PROTOCOL_CLIENT_FIELDS = {
+      "httpClient", "httpClientNoH3", "httpClientHttp1Only", "httpClientH2cPrior",
+      "httpClientH2cUpgrade"
+  };
+  private static final String STATIC_HOST = "jmeter.example.org";
+
+  private TeardownableServer server;
+  private HTTP2JettyClient client;
+
+  @After
+  public void tearDown() throws Exception {
+    if (client != null) {
+      client.stop();
+    }
+    if (server != null) {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void installsJmeterResolverOnEveryProtocolClientWhenThePlanHasADnsCacheManager()
+      throws Exception {
+    client = new HTTP2JettyClient(false, "dns-manager-test", null, staticHostManager());
+
+    for (HttpClient protocolClient : protocolClients(client)) {
+      assertThat(protocolClient.getSocketAddressResolver())
+          .isInstanceOf(JMeterDnsSocketAddressResolver.class);
+    }
+  }
+
+  @Test
+  public void keepsJettyDefaultResolverWhenThePlanHasNoDnsCacheManager() throws Exception {
+    client = new HTTP2JettyClient(false, "dns-default-test");
+    client.start();
+
+    for (HttpClient protocolClient : protocolClients(client)) {
+      assertThat(protocolClient.getSocketAddressResolver())
+          .isInstanceOf(SocketAddressResolver.Async.class);
+    }
+  }
+
+  @Test
+  public void samplesThroughAStaticHostEntryInsteadOfSystemResolution() throws Exception {
+    int port = startServer();
+    client = new HTTP2JettyClient(false, "dns-static-host-test", null, staticHostManager());
+    client.start();
+
+    HTTPSampleResult result = sampleGet(STATIC_HOST, port);
+
+    assertThat(result.isSuccessful()).isTrue();
+    assertThat(result.getResponseCode()).isEqualTo("200");
+  }
+
+  @Test
+  public void resolvesTheProxyHostAndNeverTheTargetHost() throws Exception {
+    int port = startServer();
+    RecordingDnsResolver recordingResolver = new RecordingDnsResolver();
+    client = new HTTP2JettyClient(false, "dns-proxy-test", null, recordingResolver);
+    client.start();
+
+    HTTP2Sampler sampler = newSampler("target.invalid", port);
+    sampler.setProxyHost("localhost");
+    sampler.setProxyPortInt(String.valueOf(port));
+    sampler.setProxyScheme("http");
+    try {
+      client.sample(sampler, newResult("target.invalid", port), false, 0);
+    } catch (Exception acceptable) {
+      // The proxy here is a plain HTTP server, so the exchange may well fail. What is under test
+      // is which host reached the resolver, and that is recorded before any of that matters.
+    }
+
+    assertThat(recordingResolver.resolvedHosts).contains("localhost");
+    assertThat(recordingResolver.resolvedHosts).doesNotContain("target.invalid");
+  }
+
+  @Test
+  public void clientCacheKeySeparatesSamplersByDnsCacheManager() throws Exception {
+    HTTP2Sampler withoutManager = newSampler("localhost", 8080);
+    HTTP2Sampler withManager = newSampler("localhost", 8080);
+    withManager.setDNSResolver(staticHostManager());
+    HTTP2Sampler withAnotherManager = newSampler("localhost", 8080);
+    withAnotherManager.setDNSResolver(staticHostManager());
+
+    String keyWithoutManager = profileKey(withoutManager);
+    String keyWithManager = profileKey(withManager);
+    String keyWithAnotherManager = profileKey(withAnotherManager);
+
+    assertThat(keyWithoutManager).isNotEqualTo(keyWithManager);
+    assertThat(keyWithManager).isNotEqualTo(keyWithAnotherManager);
+    assertThat(profileKey(withManager)).isEqualTo(keyWithManager);
+  }
+
+  private int startServer() throws Exception {
+    server = new ServerBuilder().withHTTP1().buildServer();
+    server.start();
+    return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+  }
+
+  private DNSCacheManager staticHostManager() {
+    DNSCacheManager dnsCacheManager = new DNSCacheManager();
+    dnsCacheManager.addHost(STATIC_HOST, "127.0.0.1");
+    return dnsCacheManager;
+  }
+
+  private HTTPSampleResult sampleGet(String domain, int port) throws Exception {
+    return client.sample(newSampler(domain, port), newResult(domain, port), false, 0);
+  }
+
+  private HTTP2Sampler newSampler(String domain, int port) {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod("GET");
+    sampler.setDomain(domain);
+    sampler.setPort(port);
+    sampler.setPath(ServerBuilder.SERVER_PATH_200);
+    sampler.setProtocol("http");
+    return sampler;
+  }
+
+  private HTTPSampleResult newResult(String domain, int port) throws Exception {
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setSampleLabel("GET_DNS_CACHE_MANAGER");
+    result.setHTTPMethod("GET");
+    result.setURL(new URL("http", domain, port, ServerBuilder.SERVER_PATH_200));
+    return result;
+  }
+
+  private static List<HttpClient> protocolClients(HTTP2JettyClient client) throws Exception {
+    List<HttpClient> clients = new CopyOnWriteArrayList<>();
+    for (String fieldName : PROTOCOL_CLIENT_FIELDS) {
+      Field field = HTTP2JettyClient.class.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      clients.add((HttpClient) field.get(client));
+    }
+    return clients;
+  }
+
+  private static String profileKey(HTTP2Sampler sampler) throws Exception {
+    Method method = HTTP2Sampler.class.getDeclaredMethod("buildProfileKey");
+    method.setAccessible(true);
+    return (String) method.invoke(sampler);
+  }
+
+  private static final class RecordingDnsResolver implements DnsResolver {
+
+    private final List<String> resolvedHosts = new CopyOnWriteArrayList<>();
+
+    @Override
+    public InetAddress[] resolve(String host) throws UnknownHostException {
+      resolvedHosts.add(host);
+      return InetAddress.getAllByName("127.0.0.1");
+    }
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientH2cFallbackTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientH2cFallbackTest.java
@@ -1,6 +1,8 @@
 package com.blazemeter.jmeter.http2.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.blazemeter.jmeter.http2.HTTP2TestBase;
 import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
@@ -10,7 +12,9 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.http.HttpFields;
@@ -81,6 +85,81 @@ public class HTTP2JettyClientH2cFallbackTest extends HTTP2TestBase {
     }
   }
 
+  /**
+   * A server that ignores {@code Upgrade: h2c} and answers the request over HTTP/1.1 has answered
+   * it: that response is the sample. Re-sending would hit the server twice for one sampler, which
+   * for anything other than a GET means the side effect happens twice, and would report only the
+   * second attempt's time.
+   */
+  @Test
+  public void anUpgradeAttemptAnsweredOverHttp11PutsOneRequestOnTheWire() throws Exception {
+    AtomicInteger requests = new AtomicInteger();
+    int port = startHttp1OnlyServer(requests);
+    // http1UpgradeRequired=true is what makes this request carry the h2c upgrade headers.
+    HTTP2JettyClient client = new HTTP2JettyClient(true, "h2c-single-request-test");
+    client.start();
+    try {
+      HTTPSampleResult result = sampleGet(client, port);
+
+      assertThat(result.isSuccessful()).isTrue();
+      assertThat(result.getResponseCode()).isEqualTo("200");
+      assertThat(requests.get()).as("requests that reached the server").isEqualTo(1);
+    } finally {
+      client.stop();
+    }
+  }
+
+  /** And the origin is remembered, so the requests after it are not upgrade attempts either. */
+  @Test
+  public void furtherRequestsToAnHttp11OriginPutOneRequestEachOnTheWire() throws Exception {
+    AtomicInteger requests = new AtomicInteger();
+    int port = startHttp1OnlyServer(requests);
+    HTTP2JettyClient client = new HTTP2JettyClient(true, "h2c-single-request-cache-test");
+    client.start();
+    try {
+      sampleGet(client, port);
+      sampleGet(client, port);
+      sampleGet(client, port);
+
+      assertThat(requests.get()).as("requests that reached the server for three samplers")
+          .isEqualTo(3);
+    } finally {
+      client.stop();
+    }
+  }
+
+  /**
+   * The other half of the rule: a server or proxy that answers the upgrade headers by refusing them
+   * did not serve the request, and that failure is one this client caused by adding headers the test
+   * plan never asked for. Those are still sent again without them.
+   */
+  @Test
+  public void onlyAnAnswerThatRefusesTheUpgradeIsSentAgain() throws Exception {
+    HTTP2JettyClient client = new HTTP2JettyClient(true, "h2c-retry-decision-test");
+    Request upgradeAttempt = newProbeRequest("http://example.invalid/")
+        .headers(h -> h.put(HttpHeader.UPGRADE, "h2c"));
+
+    for (int refused : new int[] {400, 426, 501, 505}) {
+      assertThat(shouldRetry(client, upgradeAttempt, refused))
+          .as("status %s refuses the upgrade, so the request must be sent again", refused)
+          .isTrue();
+    }
+    for (int served : new int[] {200, 201, 204, 301, 401, 403, 404, 500, 503}) {
+      assertThat(shouldRetry(client, upgradeAttempt, served))
+          .as("status %s is an answer to the request, so it must not be sent again", served)
+          .isFalse();
+    }
+  }
+
+  private static boolean shouldRetry(HTTP2JettyClient client, Request request, int status)
+      throws Exception {
+    ContentResponse response = mock(ContentResponse.class);
+    when(response.getVersion()).thenReturn(HttpVersion.HTTP_1_1);
+    when(response.getStatus()).thenReturn(status);
+    return (Boolean) invokePrivate(client, "shouldRetryAfterFailedH2cUpgrade",
+        new Class<?>[] {Request.class, ContentResponse.class}, request, response);
+  }
+
   @Test
   public void wasH2cUpgradeAttemptDetectsUpgradeHeader() throws Exception {
     HTTP2JettyClient client = newClientForReflection();
@@ -132,7 +211,17 @@ public class HTTP2JettyClientH2cFallbackTest extends HTTP2TestBase {
   }
 
   private int startHttp1OnlyServer() throws Exception {
+    return startHttp1OnlyServer(null);
+  }
+
+  /**
+   * @param requestCounter counts every request the server answered, or {@code null} to not count
+   */
+  private int startHttp1OnlyServer(AtomicInteger requestCounter) throws Exception {
     server = new ServerBuilder().withHTTP1().buildServer();
+    if (requestCounter != null) {
+      server.setRequestLog((request, response) -> requestCounter.incrementAndGet());
+    }
     server.start();
     return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
   }

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientSourceAddressTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientSourceAddressTest.java
@@ -1,0 +1,300 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.SERVER_PATH_200;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase.SourceType;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.util.JMeterUtils;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * HC4 binds the source address per request; Jetty only offers it per client, so the binding has to
+ * reach every protocol-variant client and every connector this wrapper builds - including the QUIC
+ * one, which no transport {@code doStart} propagates to - and the per-thread client cache has to
+ * stop two samplers spoofing different IPs from sharing one client.
+ */
+public class HTTP2JettyClientSourceAddressTest extends HTTP2TestBase {
+
+  private static final String[] PROTOCOL_CLIENT_FIELDS = {
+      "httpClient", "httpClientNoH3", "httpClientHttp1Only", "httpClientH2cPrior",
+      "httpClientH2cUpgrade"
+  };
+
+  private final List<String[]> savedProperties = new ArrayList<>();
+
+  private TeardownableServer server;
+  private HTTP2JettyClient client;
+  private HTTP2Sampler sampler;
+
+  @Before
+  public void setUp() throws Exception {
+    HTTP2JettyClientTestIsolation.resetSharedClientState();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (sampler != null) {
+      // Drops any client the real factory cached on this thread while sampling.
+      sampler.threadFinished();
+    }
+    if (client != null) {
+      client.stop();
+    }
+    if (server != null && server.isStarted()) {
+      server.stop();
+    }
+    for (String[] saved : savedProperties) {
+      if (saved[1] == null) {
+        JMeterUtils.getJMeterProperties().remove(saved[0]);
+      } else {
+        JMeterUtils.setProperty(saved[0], saved[1]);
+      }
+    }
+  }
+
+  @Test
+  public void bindsEveryProtocolClientToTheSourceAddress() throws Exception {
+    client = new HTTP2JettyClient(false, "source-address-clients");
+    InetAddress loopback = InetAddress.getLoopbackAddress();
+
+    client.setSourceAddress(loopback);
+
+    SocketAddress expected = new InetSocketAddress(loopback, 0);
+    for (HttpClient protocolClient : protocolClients(client)) {
+      assertThat(protocolClient.getBindAddress()).isEqualTo(expected);
+    }
+  }
+
+  @Test
+  public void bindsEveryConnectorToTheSourceAddress() throws Exception {
+    client = new HTTP2JettyClient(false, "source-address-connectors");
+    InetAddress loopback = InetAddress.getLoopbackAddress();
+
+    client.setSourceAddress(loopback);
+
+    SocketAddress expected = new InetSocketAddress(loopback, 0);
+    List<ClientConnector> connectors = trackedConnectors(client);
+    assertThat(connectors).isNotEmpty();
+    for (ClientConnector connector : connectors) {
+      assertThat(connector.getBindAddress()).isEqualTo(expected);
+    }
+  }
+
+  @Test
+  public void leavesTheBindAddressUnsetWhenNoSourceAddressApplies() throws Exception {
+    client = new HTTP2JettyClient(false, "source-address-none");
+
+    for (HttpClient protocolClient : protocolClients(client)) {
+      assertThat(protocolClient.getBindAddress()).isNull();
+    }
+  }
+
+  @Test
+  public void clearsTheBindAddressWhenTheSourceAddressIsRemoved() throws Exception {
+    client = new HTTP2JettyClient(false, "source-address-cleared");
+    client.setSourceAddress(InetAddress.getLoopbackAddress());
+
+    client.setSourceAddress(null);
+
+    for (HttpClient protocolClient : protocolClients(client)) {
+      assertThat(protocolClient.getBindAddress()).isNull();
+    }
+  }
+
+  @Test
+  public void samplesThroughTheConfiguredSourceAddress() throws Exception {
+    int port = startServer();
+    client = new HTTP2JettyClient(false, "source-address-sample");
+    client.setSourceAddress(InetAddress.getLoopbackAddress());
+    client.start();
+
+    HTTPSampleResult result = client.sample(newSampler("localhost", port),
+        newResult("localhost", port), false, 0);
+
+    assertThat(result.isSuccessful()).isTrue();
+    assertThat(result.getResponseCode()).isEqualTo("200");
+  }
+
+  @Test
+  public void connectionsActuallyLeaveFromTheConfiguredSourceAddress() throws Exception {
+    // The only assertion here that proves the bind reached the socket: without it the OS would
+    // pick 127.0.0.1 for a loopback connection. Needs an alias the platform actually owns -
+    // Linux and Windows hold all of 127.0.0.0/8, macOS only 127.0.0.1 unless one is added.
+    InetAddress alias = InetAddress.getByName("127.0.0.2");
+    assumeTrue("127.0.0.2 is not bindable on this platform", isBindable(alias));
+    int port = startServer();
+    List<String> remoteAddresses = new CopyOnWriteArrayList<>();
+    ((ServerConnector) server.getConnectors()[0]).addBean(new Connection.Listener() {
+      @Override
+      public void onOpened(Connection connection) {
+        remoteAddresses.add(connection.getEndPoint().getRemoteSocketAddress().toString());
+      }
+
+      @Override
+      public void onClosed(Connection connection) {
+        // Only the accepted address matters here.
+      }
+    });
+    client = new HTTP2JettyClient(false, "source-address-onwire");
+    client.setSourceAddress(alias);
+    client.start();
+
+    HTTPSampleResult result = client.sample(newSampler("127.0.0.1", port),
+        newResult("127.0.0.1", port), false, 0);
+
+    assertThat(result.isSuccessful()).isTrue();
+    assertThat(remoteAddresses).isNotEmpty();
+    assertThat(remoteAddresses).allSatisfy(
+        remote -> assertThat(remote).contains("127.0.0.2"));
+  }
+
+  @Test
+  public void failsTheSampleWhenTheConfiguredDeviceDoesNotExist() throws Exception {
+    int port = startServer();
+    sampler = newSampler("localhost", port);
+    sampler.setIpSource("no-such-interface");
+    sampler.setIpSourceType(SourceType.DEVICE.ordinal());
+
+    SampleResult result = sampler.sample();
+
+    // Same outcome as HC4, where getIpSourceAddress throws out of setupRequest.
+    assertThat(result.isSuccessful()).isFalse();
+    assertThat(result.getResponseCode())
+        .isEqualTo("Non HTTP response code: java.net.UnknownHostException");
+  }
+
+  @Test
+  public void clientCacheKeySeparatesSamplersByConfiguredSourceAddress() throws Exception {
+    HTTP2Sampler withoutSource = newSampler("localhost", 8080);
+    HTTP2Sampler withSource = newSampler("localhost", 8080);
+    withSource.setIpSource("127.0.0.1");
+    HTTP2Sampler withAnotherSource = newSampler("localhost", 8080);
+    withAnotherSource.setIpSource("127.0.0.2");
+    HTTP2Sampler withAnotherType = newSampler("localhost", 8080);
+    withAnotherType.setIpSource("127.0.0.1");
+    withAnotherType.setIpSourceType(SourceType.DEVICE.ordinal());
+
+    assertThat(profileKey(withoutSource)).isNotEqualTo(profileKey(withSource));
+    assertThat(profileKey(withSource)).isNotEqualTo(profileKey(withAnotherSource));
+    assertThat(profileKey(withSource)).isNotEqualTo(profileKey(withAnotherType));
+    assertThat(profileKey(withSource)).isEqualTo(profileKey(withSource));
+  }
+
+  @Test
+  public void clientCacheKeyFollowsTheLocalAddressPropertyWhenNoSamplerFieldIsSet()
+      throws Exception {
+    // Two samplers with no Source address field bind to whatever httpclient.localaddress says, so
+    // sharing a client is right while that value holds - but a cached client keeps the address it
+    // was built with, and a plan can change a JMeter property at runtime.
+    HTTP2Sampler sampler = newSampler("localhost", 8080);
+    String withoutProperty = profileKey(sampler);
+
+    overrideProperty("httpclient.localaddress", "127.0.0.1");
+    String withProperty = profileKey(sampler);
+    overrideProperty("httpclient.localaddress", "127.0.0.2");
+    String withAnotherProperty = profileKey(sampler);
+
+    assertThat(withoutProperty).isNotEqualTo(withProperty);
+    assertThat(withProperty).isNotEqualTo(withAnotherProperty);
+  }
+
+  @Test
+  public void clientCacheKeyPrefersTheSamplerFieldOverTheLocalAddressProperty() throws Exception {
+    // The field wins in resolve(), so it has to win in the key too: the property is irrelevant to
+    // what these clients bind to.
+    HTTP2Sampler sampler = newSampler("localhost", 8080);
+    sampler.setIpSource("127.0.0.1");
+    String withoutProperty = profileKey(sampler);
+
+    overrideProperty("httpclient.localaddress", "127.0.0.2");
+
+    assertThat(profileKey(sampler)).isEqualTo(withoutProperty);
+  }
+
+  private void overrideProperty(String key, String value) {
+    savedProperties.add(new String[] {key, JMeterUtils.getProperty(key)});
+    JMeterUtils.setProperty(key, value);
+  }
+
+  private static boolean isBindable(InetAddress address) {
+    try (Socket probe = new Socket()) {
+      probe.bind(new InetSocketAddress(address, 0));
+      return true;
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  private int startServer() throws Exception {
+    server = new ServerBuilder().withHTTP1().buildServer();
+    server.start();
+    return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+  }
+
+  private static HTTP2Sampler newSampler(String domain, int port) {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.GET);
+    sampler.setDomain(domain);
+    sampler.setPort(port);
+    sampler.setPath(SERVER_PATH_200);
+    sampler.setProtocol("http");
+    return sampler;
+  }
+
+  private static HTTPSampleResult newResult(String domain, int port) throws Exception {
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setSampleLabel("GET_SOURCE_ADDRESS");
+    result.setHTTPMethod(HTTPConstants.GET);
+    result.setURL(new URL("http", domain, port, SERVER_PATH_200));
+    return result;
+  }
+
+  private static List<HttpClient> protocolClients(HTTP2JettyClient client) throws Exception {
+    List<HttpClient> clients = new ArrayList<>();
+    for (String fieldName : PROTOCOL_CLIENT_FIELDS) {
+      clients.add((HttpClient) readField(client, fieldName));
+    }
+    return clients;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<ClientConnector> trackedConnectors(HTTP2JettyClient client) throws Exception {
+    return (List<ClientConnector>) readField(client, "connectors");
+  }
+
+  private static Object readField(HTTP2JettyClient client, String fieldName) throws Exception {
+    Field field = HTTP2JettyClient.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.get(client);
+  }
+
+  private static String profileKey(HTTP2Sampler sampler) throws Exception {
+    Method method = HTTP2Sampler.class.getDeclaredMethod("buildProfileKey");
+    method.setAccessible(true);
+    return (String) method.invoke(sampler);
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HttpKeepAliveSampleHeadersTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HttpKeepAliveSampleHeadersTest.java
@@ -98,6 +98,50 @@ public class HttpKeepAliveSampleHeadersTest {
     }
   }
 
+  /**
+   * A request that probes a cleartext origin for HTTP/2 has to send
+   * {@code Connection: Upgrade, HTTP2-Settings} for the upgrade to be well formed. That must not
+   * cost the sample the keep-alive the sampler asked for: a plan asserting
+   * {@code Connection: keep-alive} on its request headers - as Apache's own {@code TEST_HTTP} does -
+   * would otherwise fail on that one request, while every other request in the plan passed.
+   */
+  @Test
+  public void sampleRequestHeadersKeepKeepAliveOnAnH2cUpgradeAttempt() throws Exception {
+    configureCleartextHttp2();
+
+    try (ServerSocket serverSocket = new ServerSocket(0)) {
+      int port = serverSocket.getLocalPort();
+      Future<String> received = startWireCapture(serverSocket);
+
+      // http1UpgradeRequired=true is what makes this request carry the h2c upgrade headers.
+      HTTP2JettyClient jettyClient = new HTTP2JettyClient(true, "keepalive-h2c-upgrade-test");
+      jettyClient.start();
+      try {
+        HTTPSampleResult sampleResult = samplePlainHttp(jettyClient, port, true);
+        String wireRequest = received.get(10, TimeUnit.SECONDS);
+
+        assertThat(wireRequest).as("the upgrade attempt really went out")
+            .contains("Upgrade: h2c");
+        assertThat(wireRequest).as("and the wire keeps the header the upgrade needs")
+            .contains(HTTPConstants.HEADER_CONNECTION + ": Upgrade, HTTP2-Settings");
+        assertThat(sampleResult.getRequestHeaders())
+            .as("the sample still reports the keep-alive the sampler asked for")
+            .contains(HTTPConstants.HEADER_CONNECTION + ": " + HTTPConstants.KEEP_ALIVE);
+        assertThat(sampleResult.getRequestHeaders())
+            .as("without hiding what the request actually asked the origin for")
+            .contains("Upgrade: h2c");
+      } finally {
+        jettyClient.stop();
+      }
+    }
+  }
+
+  private static void configureCleartextHttp2() {
+    JMeterUtils.setProperty("blazemeter.http.enableHttp2", "true");
+    JMeterUtils.setProperty("blazemeter.http.enableHttp3", "false");
+    JMeterUtils.setProperty("blazemeter.http.profile", "browser-compatible");
+  }
+
   private static void configureLegacyHttp1Only() {
     JMeterUtils.setProperty("blazemeter.http.enableHttp2", "false");
     JMeterUtils.setProperty("blazemeter.http.enableHttp3", "false");

--- a/src/test/java/com/blazemeter/jmeter/http2/core/JMeterDnsSocketAddressResolverTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/JMeterDnsSocketAddressResolverTest.java
@@ -1,0 +1,203 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.http.conn.DnsResolver;
+import org.eclipse.jetty.util.Promise;
+import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Pins the contract {@link JMeterDnsSocketAddressResolver} owes Jetty when it hands over a JMeter
+ * DNS Cache Manager: every address, in order, or a failure - never an empty success, because
+ * {@code HttpClient} indexes straight into the resolved list, and never an unbounded wait, because
+ * JMeter leaves the manager's own DNS timeout unset.
+ */
+public class JMeterDnsSocketAddressResolverTest {
+
+  private static final long TIMEOUT_MS = 300;
+  private static final int AWAIT_SECONDS = 10;
+
+  private ExecutorService executor;
+  private ScheduledExecutorScheduler scheduler;
+
+  @Before
+  public void setUp() throws Exception {
+    executor = Executors.newCachedThreadPool();
+    scheduler = new ScheduledExecutorScheduler("dns-resolver-test-scheduler", true);
+    scheduler.start();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (scheduler != null) {
+      scheduler.stop();
+    }
+    if (executor != null) {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  public void resolvesEveryAddressInTheOrderTheManagerReturnedThem() throws Exception {
+    InetAddress first = InetAddress.getByName("127.0.0.1");
+    InetAddress second = InetAddress.getByName("::1");
+    CapturingPromise promise = resolve(host -> new InetAddress[] {first, second});
+
+    assertThat(promise.awaitAddresses())
+        .containsExactly(new InetSocketAddress(first, 443), new InetSocketAddress(second, 443));
+  }
+
+  @Test
+  public void failsWithUnknownHostWhenTheManagerResolvesToNull() throws Exception {
+    // DNSCacheManager.customRequestLookup returns null when dnsjava cannot parse the name, and its
+    // cache is allowed to hold a null value for a host.
+    CapturingPromise promise = resolve(host -> null);
+
+    assertThat(promise.awaitFailure()).isInstanceOf(UnknownHostException.class);
+  }
+
+  @Test
+  public void failsWithUnknownHostWhenTheManagerResolvesToNoAddress() throws Exception {
+    // JMeter's isStaticHost matches case-insensitively but fromStaticHost re-reads the entry
+    // case-sensitively, so a static host declared with different casing resolves to an empty
+    // array instead of throwing.
+    CapturingPromise promise = resolve(host -> new InetAddress[0]);
+
+    assertThat(promise.awaitFailure()).isInstanceOf(UnknownHostException.class);
+  }
+
+  @Test
+  public void propagatesTheFailureRaisedByTheManager() throws Exception {
+    UnknownHostException raised = new UnknownHostException("no.such.host");
+    CapturingPromise promise = resolve(host -> {
+      throw raised;
+    });
+
+    assertThat(promise.awaitFailure()).isSameAs(raised);
+  }
+
+  @Test
+  public void failsWithTimeoutWhenTheLookupOutlivesTheConfiguredTimeout() throws Exception {
+    CountDownLatch release = new CountDownLatch(1);
+    try {
+      CapturingPromise promise = resolve(host -> {
+        awaitQuietly(release);
+        return new InetAddress[] {InetAddress.getLoopbackAddress()};
+      });
+
+      assertThat(promise.awaitFailure()).isInstanceOf(TimeoutException.class);
+    } finally {
+      release.countDown();
+    }
+  }
+
+  @Test
+  public void serializesConcurrentLookupsOverTheSameManager() throws Exception {
+    AtomicInteger inFlight = new AtomicInteger();
+    AtomicInteger maxInFlight = new AtomicInteger();
+    JMeterDnsSocketAddressResolver resolver = newResolver(host -> {
+      maxInFlight.accumulateAndGet(inFlight.incrementAndGet(), Math::max);
+      try {
+        Thread.sleep(30);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } finally {
+        inFlight.decrementAndGet();
+      }
+      return new InetAddress[] {InetAddress.getLoopbackAddress()};
+    }, TimeUnit.SECONDS.toMillis(AWAIT_SECONDS));
+
+    CapturingPromise[] promises = new CapturingPromise[4];
+    for (int i = 0; i < promises.length; i++) {
+      promises[i] = new CapturingPromise();
+      resolver.resolve("localhost", 80, Map.of(), promises[i]);
+    }
+    for (CapturingPromise promise : promises) {
+      assertThat(promise.awaitAddresses()).hasSize(1);
+    }
+
+    assertThat(maxInFlight.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void resolvesInlineWhileTheClientHasNotProvidedAnExecutorYet() throws Exception {
+    JMeterDnsSocketAddressResolver resolver = new JMeterDnsSocketAddressResolver(
+        host -> new InetAddress[] {InetAddress.getLoopbackAddress()},
+        () -> null, () -> scheduler, TIMEOUT_MS);
+    CapturingPromise promise = new CapturingPromise();
+
+    resolver.resolve("localhost", 8080, Map.of(), promise);
+
+    assertThat(promise.awaitAddresses())
+        .containsExactly(new InetSocketAddress(InetAddress.getLoopbackAddress(), 8080));
+  }
+
+  private CapturingPromise resolve(DnsResolver dnsResolver) throws Exception {
+    CapturingPromise promise = new CapturingPromise();
+    newResolver(dnsResolver, TIMEOUT_MS).resolve("localhost", 443, Map.of(), promise);
+    return promise;
+  }
+
+  private JMeterDnsSocketAddressResolver newResolver(DnsResolver dnsResolver, long timeoutMs) {
+    return new JMeterDnsSocketAddressResolver(dnsResolver, () -> executor, () -> scheduler,
+        timeoutMs);
+  }
+
+  private static void awaitQuietly(CountDownLatch latch) {
+    try {
+      latch.await(AWAIT_SECONDS, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private static final class CapturingPromise implements Promise<List<InetSocketAddress>> {
+
+    private final CountDownLatch done = new CountDownLatch(1);
+
+    private volatile List<InetSocketAddress> addresses;
+    private volatile Throwable failure;
+
+    @Override
+    public void succeeded(List<InetSocketAddress> result) {
+      addresses = result;
+      done.countDown();
+    }
+
+    @Override
+    public void failed(Throwable throwable) {
+      failure = throwable;
+      done.countDown();
+    }
+
+    private List<InetSocketAddress> awaitAddresses() throws InterruptedException {
+      await();
+      assertThat(failure).isNull();
+      return addresses;
+    }
+
+    private Throwable awaitFailure() throws InterruptedException {
+      await();
+      assertThat(addresses).isNull();
+      return failure;
+    }
+
+    private void await() throws InterruptedException {
+      assertThat(done.await(AWAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
+    }
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/JMeterSourceAddressResolverTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/JMeterSourceAddressResolverTest.java
@@ -1,0 +1,140 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assume.assumeTrue;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.UnknownHostException;
+import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase.SourceType;
+import org.apache.jmeter.util.JMeterUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * JMeter's "Source address" field (IP spoofing) has four modes and a global fallback property, and
+ * {@code HTTPHC4Impl} resolves them in a precise order before binding the socket. This pins the
+ * port of that algorithm: the sampler field wins over {@code httpclient.localaddress}, a device
+ * mode walks the interface list for an address of the requested family, and a name that cannot be
+ * resolved throws instead of quietly falling back to the default interface.
+ */
+public class JMeterSourceAddressResolverTest extends HTTP2TestBase {
+
+  private static final String LOCAL_ADDRESS_PROPERTY = "httpclient.localaddress";
+
+  private String originalLocalAddressProperty;
+
+  @Before
+  public void setUp() {
+    originalLocalAddressProperty = JMeterUtils.getProperty(LOCAL_ADDRESS_PROPERTY);
+    JMeterUtils.getJMeterProperties().remove(LOCAL_ADDRESS_PROPERTY);
+  }
+
+  @After
+  public void tearDown() {
+    if (originalLocalAddressProperty == null) {
+      JMeterUtils.getJMeterProperties().remove(LOCAL_ADDRESS_PROPERTY);
+    } else {
+      JMeterUtils.setProperty(LOCAL_ADDRESS_PROPERTY, originalLocalAddressProperty);
+    }
+  }
+
+  @Test
+  public void resolvesNothingWhenNeitherFieldNorPropertyIsSet() throws Exception {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+
+    assertThat(JMeterSourceAddressResolver.isConfigured(sampler)).isFalse();
+    assertThat(JMeterSourceAddressResolver.resolve(sampler)).isNull();
+  }
+
+  @Test
+  public void resolvesTheFieldAsAHostNameByDefault() throws Exception {
+    HTTP2Sampler sampler = samplerWith("127.0.0.1", SourceType.HOSTNAME);
+
+    assertThat(JMeterSourceAddressResolver.isConfigured(sampler)).isTrue();
+    assertThat(JMeterSourceAddressResolver.resolve(sampler))
+        .isEqualTo(InetAddress.getByName("127.0.0.1"));
+  }
+
+  @Test
+  public void fallsBackToTheLocalAddressProperty() throws Exception {
+    JMeterUtils.setProperty(LOCAL_ADDRESS_PROPERTY, "127.0.0.1");
+    HTTP2Sampler sampler = new HTTP2Sampler();
+
+    assertThat(JMeterSourceAddressResolver.isConfigured(sampler)).isTrue();
+    assertThat(JMeterSourceAddressResolver.resolve(sampler))
+        .isEqualTo(InetAddress.getByName("127.0.0.1"));
+  }
+
+  @Test
+  public void prefersTheSamplerFieldOverTheLocalAddressProperty() throws Exception {
+    JMeterUtils.setProperty(LOCAL_ADDRESS_PROPERTY, "127.0.0.2");
+    HTTP2Sampler sampler = samplerWith("127.0.0.1", SourceType.HOSTNAME);
+
+    assertThat(JMeterSourceAddressResolver.resolve(sampler))
+        .isEqualTo(InetAddress.getByName("127.0.0.1"));
+  }
+
+  @Test
+  public void ignoresAnUnresolvableLocalAddressProperty() throws Exception {
+    // HC4 logs and carries on rather than breaking every sample in the plan over a typo in a
+    // global property; only a sampler-level field is allowed to fail a sample.
+    JMeterUtils.setProperty(LOCAL_ADDRESS_PROPERTY, "no.such.host.invalid");
+    HTTP2Sampler sampler = new HTTP2Sampler();
+
+    assertThat(JMeterSourceAddressResolver.resolve(sampler)).isNull();
+  }
+
+  @Test
+  public void resolvesTheLoopbackDeviceToAnIpv4Address() throws Exception {
+    String loopbackDevice = loopbackDeviceName();
+    assumeTrue("No named interface holds the loopback address here", loopbackDevice != null);
+    HTTP2Sampler sampler = samplerWith(loopbackDevice, SourceType.DEVICE_IPV4);
+
+    assertThat(JMeterSourceAddressResolver.resolve(sampler)).isInstanceOf(Inet4Address.class);
+  }
+
+  @Test
+  public void resolvesTheLoopbackDeviceInAnyFamilyMode() throws Exception {
+    String loopbackDevice = loopbackDeviceName();
+    assumeTrue("No named interface holds the loopback address here", loopbackDevice != null);
+    HTTP2Sampler sampler = samplerWith(loopbackDevice, SourceType.DEVICE);
+
+    assertThat(JMeterSourceAddressResolver.resolve(sampler)).isNotNull();
+  }
+
+  @Test
+  public void failsWhenTheConfiguredDeviceDoesNotExist() {
+    HTTP2Sampler sampler = samplerWith("no-such-interface", SourceType.DEVICE);
+
+    assertThatThrownBy(() -> JMeterSourceAddressResolver.resolve(sampler))
+        .isInstanceOf(UnknownHostException.class)
+        .hasMessageContaining("Cannot find interface no-such-interface");
+  }
+
+  @Test
+  public void failsWhenTheConfiguredHostNameCannotBeResolved() {
+    HTTP2Sampler sampler = samplerWith("no.such.host.invalid", SourceType.HOSTNAME);
+
+    assertThatThrownBy(() -> JMeterSourceAddressResolver.resolve(sampler))
+        .isInstanceOf(UnknownHostException.class);
+  }
+
+  private static HTTP2Sampler samplerWith(String ipSource, SourceType sourceType) {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setIpSource(ipSource);
+    sampler.setIpSourceType(sourceType.ordinal());
+    return sampler;
+  }
+
+  private static String loopbackDeviceName() throws Exception {
+    NetworkInterface loopback =
+        NetworkInterface.getByInetAddress(InetAddress.getLoopbackAddress());
+    return loopback == null ? null : loopback.getName();
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/SampleClockTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/SampleClockTest.java
@@ -1,0 +1,196 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.junit.Assume.assumeTrue;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import java.lang.reflect.Field;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.samplers.SampleResult;
+import org.junit.Test;
+
+/**
+ * A sample's start and end must come from one clock.
+ *
+ * <p>A {@link SampleResult} derives every stamp of its own from {@code System.nanoTime()} plus an
+ * offset it captures at construction, while {@link HTTP2FutureResponseListener} records the exchange
+ * on the wall clock as well. Taking a sample's start from {@code sampleStart()} and its end from the
+ * listener's wall-clock reading therefore reported the distance between those two clocks as part of
+ * the duration: single-digit milliseconds in a healthy run, but bounded only by how stale that
+ * offset is. See {@link SampleClock}.
+ *
+ * <p>The distance is made deterministic here by moving the result's own offset - the same thing a
+ * stale refresh does at runtime, only by an amount worth asserting on.
+ */
+public class SampleClockTest extends HTTP2TestBase {
+
+  private static final long SKEW_MILLIS = 250L;
+  private static final long EXCHANGE_MILLIS = 60L;
+  /** The exchange is simulated with a sleep, so its duration is a lower bound, not an equality. */
+  private static final long SCHEDULING_SLACK_MILLIS = 400L;
+  /** Two truncations to whole milliseconds, plus the gap between reading the two clocks. */
+  private static final long TRANSLATION_SLACK_MILLIS = 5L;
+
+  @Test
+  public void endTakenFromTheListenerMustNotAbsorbTheDistanceBetweenTheClocks() throws Exception {
+    HTTPSampleResult result = new HTTPSampleResult();
+    assumeSampleClockMovedBy(result, SKEW_MILLIS);
+    result.sampleStart();
+
+    HTTP2FutureResponseListener listener = new HTTP2FutureResponseListener(-1);
+    Thread.sleep(EXCHANGE_MILLIS);
+    listener.setEnd();
+
+    assertThat(listener.getResponseEnd() - result.getStartTime())
+        .as("the raw wall-clock reading the sample used to be stamped with sits before its own "
+            + "start here, which is what corrupted the duration")
+        .isNegative();
+
+    result.setEndTime(listener.getResponseEndOn(result));
+
+    assertThat(result.getTime())
+        .as("the duration must be the exchange, not the exchange shifted by %d ms of clock "
+            + "distance", SKEW_MILLIS)
+        .isBetween(EXCHANGE_MILLIS, EXCHANGE_MILLIS + SCHEDULING_SLACK_MILLIS);
+  }
+
+  @Test
+  public void endTakenFromTheListenerMustNotBeInflatedByTheDistanceBetweenTheClocks()
+      throws Exception {
+    HTTPSampleResult result = new HTTPSampleResult();
+    assumeSampleClockMovedBy(result, -SKEW_MILLIS);
+    result.sampleStart();
+
+    HTTP2FutureResponseListener listener = new HTTP2FutureResponseListener(-1);
+    Thread.sleep(EXCHANGE_MILLIS);
+    listener.setEnd();
+
+    assertThat(listener.getResponseEnd() - result.getStartTime())
+        .as("the raw wall-clock reading is %d ms ahead of this result's clock, so it used to "
+            + "inflate the sample by that much", SKEW_MILLIS)
+        .isGreaterThan(SKEW_MILLIS);
+
+    result.setEndTime(listener.getResponseEndOn(result));
+
+    assertThat(result.getTime())
+        .isBetween(EXCHANGE_MILLIS, EXCHANGE_MILLIS + SCHEDULING_SLACK_MILLIS);
+  }
+
+  @Test
+  public void anExchangeThatNeverCompletedStaysUnstampedInsteadOfBecomingAClockReading() {
+    HTTP2FutureResponseListener listener = new HTTP2FutureResponseListener(-1);
+
+    assertThat(listener.getResponseEnd()).as("no completion yet").isZero();
+    assertThat(listener.getResponseEndOn(new HTTPSampleResult()))
+        .as("an absent stamp must stay absent, so callers can tell it apart from a real end and "
+            + "fall back to sampleEnd() rather than stamping a zero")
+        .isZero();
+  }
+
+  /**
+   * The winner of a protocol race is reported through the listener of the attempt that lost, so the
+   * stamps and the monotonic readings they are translated with have to travel together: translating
+   * the winner's interval with the loser's readings would put the sample wherever the two attempts
+   * happened to be apart.
+   */
+  @Test
+  public void adoptingARaceWinnerKeepsItsIntervalOnOneClock() throws Exception {
+    HTTP2FutureResponseListener winner = new HTTP2FutureResponseListener(-1);
+    Thread.sleep(EXCHANGE_MILLIS);
+    winner.setEnd();
+    HTTP2FutureResponseListener reporter = new HTTP2FutureResponseListener(-1);
+
+    reporter.completeWith(null, winner);
+
+    HTTPSampleResult result = new HTTPSampleResult();
+    assumeSampleClockMovedBy(result, SKEW_MILLIS);
+    assertThat(reporter.getResponseEndOn(result) - reporter.getResponseStartOn(result))
+        .as("the reported interval must be the winner's exchange")
+        .isBetween(EXCHANGE_MILLIS - TRANSLATION_SLACK_MILLIS,
+            EXCHANGE_MILLIS + SCHEDULING_SLACK_MILLIS);
+    assertThat(reporter.getResponseEndOn(result) - winner.getResponseEndOn(result))
+        .as("both listeners must translate the same instant to the same time")
+        .isBetween(-TRANSLATION_SLACK_MILLIS, TRANSLATION_SLACK_MILLIS);
+    assertThat(reporter.isDone()).isTrue();
+  }
+
+  /** Stamps adopted from elsewhere as plain wall-clock times still land on the result's clock. */
+  @Test
+  public void adoptedWallClockStampsAreTranslatedIntoTheResultsClock() throws Exception {
+    HTTPSampleResult result = new HTTPSampleResult();
+    assumeSampleClockMovedBy(result, -SKEW_MILLIS);
+
+    long start = System.currentTimeMillis();
+    HTTP2FutureResponseListener listener = new HTTP2FutureResponseListener(-1);
+    listener.completeWith(null, start, start + EXCHANGE_MILLIS);
+
+    assertThat(listener.getResponseEndOn(result) - listener.getResponseStartOn(result))
+        .as("translating both ends of the same interval must preserve it")
+        .isEqualTo(EXCHANGE_MILLIS);
+    assertThat(listener.getResponseStartOn(result) - start)
+        .as("both stamps must land on the result's clock, %d ms from the wall clock here",
+            -SKEW_MILLIS)
+        .isBetween(-SKEW_MILLIS - TRANSLATION_SLACK_MILLIS,
+            -SKEW_MILLIS + TRANSLATION_SLACK_MILLIS);
+  }
+
+  /**
+   * {@code SampleResult.setStampAndTime} reads its first argument as the start of the sample or as
+   * its end depending on {@code sampleresult.timestamp.start} - JMeter's shipped
+   * {@code jmeter.properties} turns that on, the property's own default is off. A caller that
+   * assumes either one gets the timestamps of the other backwards by the whole duration, which for
+   * a sub-sample also drags the container's end with it. So the choice belongs in one place.
+   */
+  @Test
+  public void stampIntervalReportsTheStartAndTheDurationItWasGiven() {
+    SampleResult result = new SampleResult();
+
+    SampleClock.stampInterval(result, 1_000_000L, 250L);
+
+    assertThat(result.getStartTime()).as("start").isEqualTo(1_000_000L);
+    assertThat(result.getEndTime()).as("end").isEqualTo(1_000_250L);
+    assertThat(result.getTime()).as("duration").isEqualTo(250L);
+  }
+
+  /**
+   * A sub-sample's times are on its own clock, and JMeter corrects for that when it folds one into
+   * its parent - {@code SampleResult.addSubResult} extends the parent's end time by
+   * {@code childEnd + parentOffset - childOffset}, its Bug 51855. Reading a child's stamps to
+   * measure the parent has to make the same correction, so both must land on the same time.
+   */
+  @Test
+  public void aChildsTimesLandWhereAddSubResultPutsThem() throws Exception {
+    SampleResult parent = new SampleResult();
+    parent.sampleStart();
+    HTTPSampleResult child = new HTTPSampleResult();
+    assumeSampleClockMovedBy(child, SKEW_MILLIS);
+    child.sampleStart();
+    child.sampleEnd();
+
+    parent.addSubResult(child, false);
+
+    assertThat(SampleClock.fromResultClock(parent, child, child.getEndTime()))
+        .as("the child's end on the parent's clock must be the end addSubResult stamped")
+        .isCloseTo(parent.getEndTime(), within(TRANSLATION_SLACK_MILLIS));
+    assertThat(parent.getEndTime() - child.getEndTime())
+        .as("and the raw stamp is %d ms away from it, which is what reading it uncorrected costs",
+            SKEW_MILLIS)
+        .isCloseTo(-SKEW_MILLIS, within(TRANSLATION_SLACK_MILLIS));
+  }
+
+  /**
+   * Moves {@code result}'s own nano offset by {@code deltaMillis}, so its clock sits a known
+   * distance from the wall clock. Skips the test when {@code sampleresult.useNanoTime} is off, since
+   * both clocks are then the wall clock and there is no distance to leak.
+   */
+  private static void assumeSampleClockMovedBy(SampleResult result, long deltaMillis)
+      throws ReflectiveOperationException {
+    Field nanoTimeOffset = SampleResult.class.getDeclaredField("nanoTimeOffset");
+    nanoTimeOffset.setAccessible(true);
+    long current = nanoTimeOffset.getLong(result);
+    assumeTrue("sampleresult.useNanoTime must be on for the two clocks to differ at all",
+        current != Long.MIN_VALUE);
+    nanoTimeOffset.setLong(result, current + deltaMillis);
+  }
+}


### PR DESCRIPTION
This pull request introduces new features and documentation updates for the BlazeMeter HTTP plugin, focusing on improved control over timing and logging, along with dependency updates. The most significant changes are the addition of a new scheduler hold property for async controllers, expanded documentation on logging and debugging, and dependency upgrades for better stability and compatibility.

**New features and configuration:**

* Added support for a new property, `blazemeter.http.schedulerHoldMillis`, which controls how long the `bzm - HTTP Async Controller` will hold a thread at the end of a timed run to collect responses from in-flight requests, matching JMeter's graceful shutdown behavior. This is now documented and implemented in the code. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R388-R398) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R416) [[3]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48R63-R94) [[4]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48R104)

**Documentation improvements:**

* Expanded the `README.md` with a new section on Logging and low-level debugging, including detailed instructions on enabling internal plugin traces and controlling Jetty's logging verbosity. This helps users diagnose issues without overwhelming logs during load tests. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R50-R51) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R446-R489)
* Updated the Async Controller documentation to clarify timing behavior and new configuration options, including the new scheduler hold property and how timers/pre-post processors are included in parent sample timing. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R379) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R388-R398)

**Dependency and version updates:**

* Upgraded the plugin version to `3.2.0` and updated the `log4j` dependency from `2.22.1` to `2.25.5` in `pom.xml` for improved security and compatibility. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L7-R7) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L40-R40)

**Internal code enhancements:**

* Refactored `HTTP2Controller.java` to support the new scheduler hold property, improved state tracking for parent transactions, and prepared for more granular control over sample timing and logging. [[1]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48R3-R6) [[2]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48R19) [[3]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48R63-R94) [[4]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48R104)


**Connection Failure Tracking and Reporting**
- Added the `ConnectAttemptRecorder` class to record all connection failures for each address attempted, and attach them as suppressed exceptions to the main failure, improving visibility into all failed connection attempts, not just the final one. (`ConnectAttemptRecorder.java`)
- Updated the HTTP/2 prior knowledge client transport instantiation to pass the `ConnectAttemptRecorder`, ensuring all connection attempts are captured. (`HTTP2JettyClient.java`)
- Replaced usages of `HttpClientTransportDynamic` with a new `RecordingHttpClientTransportDynamic` to support connection attempt recording across all protocol variants. (`HTTP2JettyClient.java`) [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL571-R612) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL588-R636) [[3]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL614-R656) [[4]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL1231-R1275)

**HTTP/2 Rejection Handling**
- Implemented an `onHttp2Rejected` callback, which marks an origin as HTTP/1.1-only if it rejects the HTTP/2 preface, avoiding repeated failed attempts for future requests to that origin. (`HTTP2JettyClient.java`) [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR3111-R3132) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL433-R473) [[3]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL2089-R2134)

**Infrastructure and Constructor Updates**
- Extended the `HTTP2JettyClient` constructor to accept a `DnsResolver` and initialize the `ConnectAttemptRecorder` and connector tracking, preparing the client for improved DNS and connection handling. (`HTTP2JettyClient.java`)

These changes together provide much richer error reporting and smarter protocol fallback behavior, improving both developer diagnostics and end-user experience.