### PR TITLE
Collect in-flight requests on Thread Group duration end

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ This plugin provides a `bzm - HTTP Sampler` (multi-protocol: **HTTP/1.1**, **HTT
 - [**HTTP Async Controller**](#readme-http-async-controller)
   - [Controller panel](#readme-http-async-panel)
 - [**JMeter property reference**](#readme-jmeter-property-reference)
+- [**Logging and low-level debugging**](#readme-logging)
+  - [Keeping Jetty's own logging out of it](#readme-logging-jetty-verbosity)
 - [**Building from source**](#readme-building-from-source)
 - [**License**](#readme-license)
 
@@ -383,11 +385,16 @@ In **View Results Tree**, rows may follow **completion order**, not test-plan or
 > [!NOTE]
 > Anything else you add as a **direct child**—timers, a different sampler type, an assertion, another controller, etc.—still runs **in tree order**. Before that element runs, the controller **waits until every BlazeMeter HTTP request started above it has completed**. Use that pattern when you mean “kick off these BlazeMeter HTTP calls together, then run the following steps only after they are all done.”
 
+> [!NOTE]
+> **When a Thread Group runs for a duration**, the requests this controller had already sent when the time ran out are still collected and reported, the same way JMeter lets a running request finish before it stops a thread. Nothing new is dispatched once the time is up, so no load reaches the system under test past the end of the run; the thread ends as soon as the responses it was already waiting for arrive. Tune or disable that grace with **`blazemeter.http.schedulerHoldMillis`**. A **Stop** is immediate and is never held off.
+
 
 <a id="readme-jmeter-property-reference"></a>
 # JMeter property reference
 
 Restart JMeter after changing JMeter properties that are applied when affected classes initialize.
+
+The diagnostic switches are **not** in this table: `blazemeter.http.lowLevelLog` is read as a JVM system property, not as a JMeter property — see **[Logging and low-level debugging](#readme-logging)**.
 
 | **Attribute** | **Description** | **Default** |
 |---|---|---:|
@@ -406,6 +413,7 @@ Restart JMeter after changing JMeter properties that are applied when affected c
 | **blazemeter.http.maxConcurrentPushedStreams** | Maximum number of server push streams concurrently received | 100 |
 | **blazemeter.http.maxRequestsPerConnection** | Maximum Jetty HTTP requests per pooled connection | 100 |
 | **blazemeter.http.maxConcurrentAsyncInController** | Default concurrency cap inside **`bzm - HTTP Async Controller`** when parallel limiting is unchecked | 100 |
+| **blazemeter.http.schedulerHoldMillis** | How far **`bzm - HTTP Async Controller`** may push a thread's scheduled end while its requests are still on the wire, so a duration-limited run collects the responses it already asked for instead of dropping them. Renewed while requests are pending and given back as soon as they are collected; a Stop is never held off. Set to **0** to let the schedule cut mid-flight | 2000 |
 | **HTTPSampler.response_timeout** | Default response timeout (ms) when the sampler defines none | 0 |
 | **http.post_add_content_type_if_missing** | Add Content-Type header if missing? | false |
 | **blazemeter.http.enableHttp3** | Enable HTTP/3 support (Alt-Svc + QUIC) | profile |
@@ -433,6 +441,50 @@ Restart JMeter after changing JMeter properties that are applied when affected c
 | **blazemeter.http.controller.generateParentSample** | If you group all requests into a parent sample | false |
 | **blazemeter.http.controller.limitMaxParallel** | Limit max number of parallel executions | false |
 | **blazemeter.http.controller.maxConcurrentAsyncInController** | Maximum parallel requests (integer ≥ 1) | 100 |
+
+
+<a id="readme-logging"></a>
+# Logging and low-level debugging
+
+The plugin logs through JMeter's own logging, so its lines land in **`jmeter.log`** next to JMeter's, under logger names like **`c.b.j.h.c.HTTP2Controller`** and **`c.b.j.h.c.HTTP2JettyClient`**. Warnings and errors are on by default. Everything below is for diagnosing a run and should be **off during a load test**: with both switches on, a single-thread nine-second run with two requests per iteration wrote about **2900 lines**, and that scales with threads and requests.
+
+Two switches, and they do different things:
+
+| **Switch** | **What it does** |
+|---|---|
+| **`-Dblazemeter.http.lowLevelLog=true`** | Opens the plugin's internal traces: every dispatch and completion in the async controller, the request/response steps in the client, protocol negotiation and fallback decisions, plus HTTP/2 frame logging. A **JVM system property** — see the note below |
+| **`-Lcom.blazemeter=DEBUG`** | Raises the log level so DEBUG lines are written at all. Without it the switch above produces nothing |
+
+> [!IMPORTANT]
+> **`-Dblazemeter.http.lowLevelLog=true`**, not `-J`. This one is read as a JVM system property, so JMeter's `-J` (test-plan properties) does **not** set it. In the GUI, or in any launcher script, pass it through **`JVM_ARGS`** instead: `set JVM_ARGS=-Dblazemeter.http.lowLevelLog=true` on Windows, `export JVM_ARGS="-Dblazemeter.http.lowLevelLog=true"` on Linux/macOS.
+
+<a id="readme-logging-jetty-verbosity"></a>
+### Keeping Jetty's own logging out of it
+
+The packaged JAR relocates its Jetty into **`com.blazemeter.jmeter.http2.shaded.org.eclipse.jetty`**, which sits *under* `com.blazemeter`. So **`-Lcom.blazemeter=DEBUG` also turns on all of Jetty's internal logging** — selectors, connection pools, buffer pools, TLS — and that is not something the plugin's own switch has any say over. On a two-iteration plan with two requests each, that is **2659 Jetty lines against 261 from the plugin**.
+
+Silence that package and the log becomes readable:
+
+```bash
+java -Dblazemeter.http.lowLevelLog=true -jar $JMETER_HOME/bin/ApacheJMeter.jar \
+  -n -t plan.jmx -l results.jtl -j run.log \
+  -Lcom.blazemeter=DEBUG -Lcom.blazemeter.jmeter.http2.shaded=INFO
+```
+
+For a permanent setting, or for the GUI, put the same two levels in **`$JMETER_HOME/bin/log4j2.xml`**:
+
+```xml
+<Loggers>
+  <Logger name="com.blazemeter" level="debug"/>
+  <!-- The plugin's relocated Jetty: leave it at info or the plugin's own lines are buried. -->
+  <Logger name="com.blazemeter.jmeter.http2.shaded" level="info"/>
+</Loggers>
+```
+
+Turn Jetty's own logging **on** only when the question is about the transport itself (a stalled connection, a TLS handshake, HTTP/2 frames) — by dropping that second logger, or by raising just one package, e.g. `-Lcom.blazemeter.jmeter.http2.shaded.org.eclipse.jetty.io=DEBUG`.
+
+> [!NOTE]
+> With the low-level switch on, the client also appends HTTP/2 frame traces to an **`http2-debug.log`** file, resolved relative to the working directory JMeter was started from (`<cwd>/jmeter-http2-plugin/target/http2-debug.log`). It is created only while that switch is on.
 
 
 <a id="readme-building-from-source"></a>

--- a/src/main/java/com/blazemeter/jmeter/http2/control/HTTP2Controller.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/control/HTTP2Controller.java
@@ -1,5 +1,7 @@
 package com.blazemeter.jmeter.http2.control;
 
+import static com.blazemeter.jmeter.http2.core.LowLevelDebugLog.lowLevelDebug;
+
 import com.blazemeter.jmeter.http2.core.HTTP2FutureResponseListener;
 import com.blazemeter.jmeter.http2.core.SampleClock;
 import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
@@ -67,7 +69,11 @@ public class HTTP2Controller extends TransactionController implements Serializab
   private static final String COMPLETION_TIMEOUT_PROP =
       "httpJettyClient.asyncControllerCompletionTimeout";
   private static final long DEFAULT_COMPLETION_TIMEOUT_MILLIS = 120_000;
+  // New setting, so it carries the preferred name; getPropDefault still takes the legacy prefixes.
+  private static final String SCHEDULER_HOLD_PROP = "blazemeter.http.schedulerHoldMillis";
+  private static final long DEFAULT_SCHEDULER_HOLD_MILLIS = 2_000;
   private int maxConcurrentAsyncInController = DEFAULT_MAX_CONCURRENT_ASYNC_IN_CONTROLLER;
+  private long schedulerHoldMillis = DEFAULT_SCHEDULER_HOLD_MILLIS;
 
   private transient List<HTTP2Sampler> http2SamplesSync = new ArrayList<>();
   private transient boolean handingOutPendingSampler;
@@ -79,6 +85,13 @@ public class HTTP2Controller extends TransactionController implements Serializab
    * {@code super.triggerEndOfLoop()} returns.
    */
   private transient TransactionSampler openParentTransaction;
+  /**
+   * The thread's own scheduled end while this controller is holding it off, or {@code null} when it
+   * is not. See {@link #holdSchedulerWhileRequestsAreInFlight()}.
+   */
+  private transient Long heldSchedulerEndTime;
+  /** How many children the open transaction had when its span was last measured. */
+  private transient int measuredChildren;
 
   public HTTP2Controller() {
     super();
@@ -88,6 +101,7 @@ public class HTTP2Controller extends TransactionController implements Serializab
             String.valueOf(maxConcurrentAsyncInController)));
     generateControllerSample =
         BzmHttpPluginProperties.getControllerPropDefault(GENERATE_PARENT_SAMPLE_PREF, false);
+    schedulerHoldMillis = resolveSchedulerHoldMillis();
   }
 
   public void setLimitMaxParallel(boolean enabled) {
@@ -156,20 +170,122 @@ public class HTTP2Controller extends TransactionController implements Serializab
    */
   @Override
   public Sampler next() {
-    if (isGenerateParentSample()) {
-      Sampler next = super.next();
-      measureParentSample(next);
-      // Only after the controller has finished the parent transaction (next == null). Releasing
-      // while still returning the done TransactionSampler is pointless: JMeterThread calls
-      // configureTransactionSampler(done) next and puts that same instance back on the package.
-      // Releasing on the following null turn is what sticks — and runs after listeners/assertions
-      // in doEndTransactionSampler (same sequencing as JMeter PR #6386's TestCompiler.done() hook).
-      if (next == null) {
-        releaseCompletedParentTransactionSample();
+    try {
+      if (isGenerateParentSample()) {
+        Sampler next = super.next();
+        measureParentSample(next);
+        // Only after the controller has finished the parent transaction (next == null). Releasing
+        // while still returning the done TransactionSampler is pointless: JMeterThread calls
+        // configureTransactionSampler(done) next and puts that same instance back on the package.
+        // Releasing on the following null turn is what sticks — and runs after listeners/assertions
+        // in doEndTransactionSampler (same sequencing as JMeter PR #6386's TestCompiler.done()
+        // hook).
+        if (next == null) {
+          releaseCompletedParentTransactionSample();
+        }
+        return next;
       }
-      return next;
+      return nextWithoutTransactionBookkeeping();
+    } finally {
+      // After the turn, not before it: the request this turn dispatched is only on the wire once
+      // getCurrentElement has run, and what the scheduler checks right after this call returns is
+      // whether anything is out there now.
+      holdSchedulerWhileRequestsAreInFlight();
     }
-    return nextWithoutTransactionBookkeeping();
+  }
+
+  /**
+   * Keeps the thread's scheduled end from landing while this controller still has requests on the
+   * wire, and gives it back the moment they are all collected.
+   *
+   * <p>A stock sampler never loses a response to the schedule: {@code JMeterThread} checks the
+   * scheduled end in {@code stopSchedulerIfNeeded}, which runs after {@code executeSamplePackage}
+   * returns, so a request that is already out always gets to finish and be reported, and the
+   * transaction it belongs to closes with it inside. This controller has requests out across
+   * turns instead of inside one, so the same check lands between them: the thread stops with
+   * responses already on their way back, their samples are never reported, and the transaction they
+   * belonged to closes empty - a 0 ms row with no children, one per thread per run, which is enough
+   * to drag a label's Min to zero.
+   *
+   * <p>What is held off is only the scheduler's own deadline, through {@link JMeterThread}'s public
+   * end time, and only forward: a Stop, a shutdown or an interrupt do not go through it and are not
+   * affected. The push is small and renewed on every turn and on every completion poll, so the
+   * overrun is the time the pending responses need and nothing more; if this controller ever failed
+   * to give the deadline back, the last push expires on its own within
+   * {@code blazemeter.http.schedulerHoldMillis}.
+   *
+   * <p>Only the responses already asked for are waited on: once the real end has gone by,
+   * {@link #getCurrentElement()} stops dispatching the rest of the children rather than sending
+   * requests the run was over before making.
+   *
+   * <p>An empty queue is not the moment to give the deadline back: the response collected last has
+   * been handed to {@code JMeterThread} but not yet turned into a sample, and giving the deadline
+   * back on that same turn lets the scheduler stop the thread before it does - which loses exactly
+   * the response this was holding the thread for. The deadline goes back at the end of the
+   * iteration instead (see {@link #discardPendingAsyncSamples()}, reached through
+   * {@code reInitialize}), by which point every collected response has been reported; and since it
+   * stops being renewed as soon as the queue empties, a push left behind by any path that does not
+   * reach that point expires on its own.
+   */
+  private void holdSchedulerWhileRequestsAreInFlight() {
+    if (http2SamplesSync.isEmpty()) {
+      return;
+    }
+    JMeterThread thread = JMeterContextService.getContext().getThread();
+    if (thread == null || thread.getEndTime() <= 0) {
+      return; // Not a scheduled run: nothing is going to cut this thread short.
+    }
+    long hold = System.currentTimeMillis() + schedulerHoldMillis;
+    if (heldSchedulerEndTime == null) {
+      if (hold <= thread.getEndTime()) {
+        return; // The scheduled end is far enough away to collect what is out there.
+      }
+      heldSchedulerEndTime = thread.getEndTime();
+      lowLevelDebug("Holding the scheduled end of {} while {} request(s) are in flight in '{}'",
+          thread.getThreadName(), http2SamplesSync.size(), getName());
+    }
+    thread.setEndTime(hold);
+  }
+
+  /**
+   * Whether the thread's own scheduled end has already gone by while this controller was holding it
+   * off. Read from the end time that was saved, not from the thread, whose end time is the held one
+   * while the hold is on.
+   */
+  private boolean scheduledEndPassed() {
+    return heldSchedulerEndTime != null && System.currentTimeMillis() >= heldSchedulerEndTime;
+  }
+
+  /** Gives the thread back its own scheduled end, so the next check can stop it. */
+  private void releaseScheduler() {
+    if (heldSchedulerEndTime == null) {
+      return;
+    }
+    JMeterThread thread = JMeterContextService.getContext().getThread();
+    if (thread != null) {
+      thread.setEndTime(heldSchedulerEndTime);
+      lowLevelDebug("Scheduled end of {} restored: nothing left in flight in '{}'",
+          thread.getThreadName(), getName());
+    }
+    heldSchedulerEndTime = null;
+  }
+
+  /**
+   * Resolved once, at construction, like the other settings of this controller: this is read from
+   * the completion poll loop, which runs every {@value #COMPLETION_POLL_INTERVAL_MILLIS} ms for
+   * every thread that has a request out, and a JMeter property read is a synchronized map lookup
+   * per accepted name.
+   */
+  private static long resolveSchedulerHoldMillis() {
+    String configured = BzmHttpPluginProperties.getPropDefault(
+        SCHEDULER_HOLD_PROP, String.valueOf(DEFAULT_SCHEDULER_HOLD_MILLIS));
+    try {
+      return Math.max(0, Long.parseLong(configured.trim()));
+    } catch (NumberFormatException e) {
+      LOG.warn("Invalid {}='{}', falling back to {} ms", SCHEDULER_HOLD_PROP, configured,
+          DEFAULT_SCHEDULER_HOLD_MILLIS);
+      return DEFAULT_SCHEDULER_HOLD_MILLIS;
+    }
   }
 
   /**
@@ -183,32 +299,35 @@ public class HTTP2Controller extends TransactionController implements Serializab
    * the children instead, which double counts requests that ran at the same time. So the span is
    * measured here, out of the children's own stamps, exactly as this controller did up to v3.0.1.
    *
-   * <p>Also stamps an end time on a transaction that is still open. A transaction that never gets
-   * one reports {@code 0 - startTime}: {@code setTransactionDone} only stamps it in the
-   * "include timers" off branch, and {@code JMeterThread} does not call it at all when the run is
-   * cut short - the scheduler expiring, a manual Stop - it just ends the open transaction where it
-   * stands. An enclosing Transaction Controller then folds that result in through
-   * {@code SampleResult.addSubResult}, whose {@code Math.max} keeps the zero, and the enclosing
-   * sample comes out as a negative epoch that wrecks the Average and the Min of every aggregate
-   * over the run.
+   * <p>Measured on every turn, not only when the transaction is closed here, because it is not
+   * always closed here: {@code JMeterThread} ends whatever transaction is open when a run is cut
+   * short, without going through {@code setTransactionDone} and without asking this controller
+   * again. A transaction that has never been measured reports {@code 0 - startTime} - an epoch,
+   * which an enclosing Transaction Controller then folds in through
+   * {@code SampleResult.addSubResult}, whose {@code Math.max} keeps the zero - and one that was
+   * only measured when it closed would report, on that path, the wall clock this exists to correct.
+   * Keeping the open transaction measured as it goes means that however it ends, it already says
+   * what it ran.
    */
   private void measureParentSample(Sampler next) {
     if (!(next instanceof TransactionSampler)) {
       return;
     }
     TransactionSampler transactionSampler = (TransactionSampler) next;
-    if (transactionSampler.isTransactionDone()) {
-      openParentTransaction = null;
-      applyRequestSpan(transactionSampler);
+    openParentTransaction = transactionSampler.isTransactionDone() ? null : transactionSampler;
+    SampleResult parent = transactionSampler.getTransactionResult();
+    if (parent == null) {
       return;
     }
-    openParentTransaction = transactionSampler;
-    SampleResult parent = transactionSampler.getTransactionResult();
-    if (parent != null && parent.getEndTime() == 0) {
-      // Floor: a transaction ended from the outside now reports 0 ms instead of -startTime. Every
-      // child that arrives afterwards pushes it forward again through addSubResult's Math.max.
-      parent.setEndTime(parent.getStartTime());
+    // Only when there is something new to measure. A sample's stamps are final once it is reported,
+    // so the span can only move when a child joins - and walking every child on every turn of every
+    // request would be quadratic on a controller holding many of them.
+    int children = parent.getSubResults().length;
+    if (children == measuredChildren && parent.getEndTime() != 0) {
+      return;
     }
+    measuredChildren = children;
+    applyRequestSpan(transactionSampler);
   }
 
   /**
@@ -220,11 +339,16 @@ public class HTTP2Controller extends TransactionController implements Serializab
    * @see #isIncludeTimers()
    */
   private void applyRequestSpan(TransactionSampler transactionSampler) {
-    if (isIncludeTimers()) {
-      return;
-    }
     SampleResult parent = transactionSampler.getTransactionResult();
     if (parent == null) {
+      return;
+    }
+    if (isIncludeTimers()) {
+      if (parent.getEndTime() == 0) {
+        // The wall clock is what was asked for, but an end time there has to be: a transaction
+        // ended from the outside before its first child arrived would otherwise report the epoch.
+        parent.setEndTime(parent.getStartTime());
+      }
       return;
     }
     long firstStart = Long.MAX_VALUE;
@@ -448,7 +572,7 @@ public class HTTP2Controller extends TransactionController implements Serializab
       long deadline = System.currentTimeMillis() + timeout;
       while (!interrupted) {
         if (http2FListener.isDone() || http2FListener.isCancelled()) {
-          LOG.debug("HTTP Future Finished, retrying the sample with that data {}",
+          lowLevelDebug("HTTP Future Finished, retrying the sample with that data {}",
               describeRequest(http2FListener));
           return dequeueForCompletion(http2Sam);
         }
@@ -460,6 +584,9 @@ public class HTTP2Controller extends TransactionController implements Serializab
         }
         try {
           Thread.sleep(COMPLETION_POLL_INTERVAL_MILLIS);
+          // Renewed from inside the wait too: the scheduled end is only ever read between turns,
+          // and this loop is what makes a turn last as long as a response does.
+          holdSchedulerWhileRequestsAreInFlight();
         } catch (InterruptedException e) {
           http2SamplesSync.clear();
           interrupted = true;
@@ -509,7 +636,7 @@ public class HTTP2Controller extends TransactionController implements Serializab
 
   @Override
   protected TestElement getCurrentElement() throws NextIsNullException {
-    LOG.debug("Current {} Size {}", current, subControllersAndSamplers.size());
+    lowLevelDebug("Current {} Size {}", current, subControllersAndSamplers.size());
     handingOutPendingSampler = false;
 
     if (http2SamplesSync.size() > getEffectiveMaxConcurrentAsyncInController()) {
@@ -517,6 +644,16 @@ public class HTTP2Controller extends TransactionController implements Serializab
       if (!Objects.isNull(http2samDone)) {
         return handOutWithoutAdvancing(http2samDone);
       }
+    }
+
+    if (scheduledEndPassed()) {
+      // The run is over: collect what is already on the wire and end the iteration on it. Holding
+      // the thread alive is for the responses this controller already asked for, not a licence to
+      // keep asking - the remaining children would be load applied past the end of the test.
+      lowLevelDebug("Scheduled end reached with {} request(s) in flight in '{}'; collecting them "
+          + "and skipping the rest of the controller", http2SamplesSync.size(), getName());
+      HTTP2Sampler http2samDone = waitForDoneHTTP2();
+      return Objects.isNull(http2samDone) ? null : handOutWithoutAdvancing(http2samDone);
     }
 
     if (current < subControllersAndSamplers.size()) {
@@ -533,7 +670,7 @@ public class HTTP2Controller extends TransactionController implements Serializab
     }
     if (current == (subControllersAndSamplers.size())) {
       // On the last, force a checkpoint moment
-      LOG.debug("The last, force checkpoint");
+      lowLevelDebug("The last, force checkpoint");
       HTTP2Sampler http2samDone = waitForDoneHTTP2();
       if (!Objects.isNull(http2samDone)) {
         return handOutWithoutAdvancing(http2samDone);
@@ -545,7 +682,7 @@ public class HTTP2Controller extends TransactionController implements Serializab
   /** Switches a sampler to asynchronous mode and queues it for a later completion turn. */
   private HTTP2Sampler dispatchAsync(HTTP2Sampler sampler) {
     sampler.setSyncRequest(false); // Force to run async the first time
-    LOG.debug("Convert http2 sample to Async and add to wait list");
+    lowLevelDebug("Convert http2 sample to Async and add to wait list");
     http2SamplesSync.add(sampler);
     return sampler;
   }
@@ -618,6 +755,7 @@ public class HTTP2Controller extends TransactionController implements Serializab
    */
   private void discardPendingAsyncSamples() {
     if (http2SamplesSync.isEmpty()) {
+      releaseScheduler();
       return;
     }
     LOG.warn("Discarding {} in-flight async sample(s) left by an interrupted iteration of {}",
@@ -632,5 +770,8 @@ public class HTTP2Controller extends TransactionController implements Serializab
       pending.clearPendingSampleState();
     }
     http2SamplesSync.clear();
+    // Nothing is on the wire any more, so the thread gets its own scheduled end back even on the
+    // paths that gave up on the queue rather than draining it.
+    releaseScheduler();
   }
 }

--- a/src/test/java/com/blazemeter/jmeter/http2/control/HTTP2ControllerTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/control/HTTP2ControllerTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.jmeter.control.NextIsNullException;
 import org.apache.jmeter.control.TransactionController;
+import org.apache.jmeter.control.TransactionSampler;
 import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
 import org.apache.jmeter.protocol.http.sampler.HTTPSampler;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
@@ -231,6 +232,30 @@ public class HTTP2ControllerTest extends HTTP2TestBase {
     c.setProperty(BzmHttpPluginProperties.CONTROLLER_LEGACY_PREFIX + "limitMaxParallel", false);
     c.setProperty(BzmHttpPluginProperties.CONTROLLER_PREFERRED_PREFIX + "limitMaxParallel", true);
     assertThat(c.isLimitMaxParallel()).isTrue();
+  }
+
+  /**
+   * Issue #155: a transaction that is still open must already carry an end time, because nothing
+   * guarantees it will be closed by this controller. {@code JMeterThread} ends whatever transaction
+   * is open when a run is cut short, without going through {@code setTransactionDone}, and an end
+   * time left at 0 makes {@code elapsed = end - start} report minus the epoch - directly when the
+   * controller is at the top level, and through {@code addSubResult}'s {@code Math.max} when it is
+   * nested in another transaction.
+   */
+  @Test
+  public void anOpenParentTransactionAlreadyCarriesAnEndTime() throws URISyntaxException {
+    setupHttp2Controller(false, 1);
+    http2Controller.setGenerateControllerSample(true);
+    // GenericController.first has no initialiser, so a controller that was never initialised never
+    // opens its transaction. JMeter does this before the run.
+    http2Controller.initialize();
+
+    Sampler first = http2Controller.next();
+
+    assertThat(first).isInstanceOf(TransactionSampler.class);
+    SampleResult parent = ((TransactionSampler) first).getTransactionResult();
+    assertThat(parent.getEndTime()).as("end time of an open transaction").isPositive();
+    assertThat(parent.getTime()).as("reported time of an open transaction").isNotNegative();
   }
 
   /**

--- a/src/test/java/com/blazemeter/jmeter/http2/control/async/AsyncControllerTransactionTimingTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/control/async/AsyncControllerTransactionTimingTest.java
@@ -127,6 +127,15 @@ public class AsyncControllerTransactionTimingTest extends HTTP2TestBase {
     softly.assertAll();
   }
 
+  /**
+   * A Stop goes straight onto the running flag, so unlike the scheduled end of
+   * {@link #t5RequestsAlreadyOnTheWireMustSurviveTheScheduledEnd()} it cannot be held off: whatever
+   * this controller had on the wire is lost. What must not happen is a poisoned row getting out -
+   * the transaction that was open when the Stop landed reporting minus the epoch. Landing while the
+   * controller waits for a response, the Stop is seen by {@code JMeterThread}'s own loop before
+   * {@code processSampler} runs again, so usually nothing is reported at all; that the run stops,
+   * and that nothing bogus reaches a listener either way, is what is asserted.
+   */
   @Test
   public void t4ATransactionCutShortMustNotReportANegativeSampleTime() {
     TreeShape shape = fixture -> new AsyncScenarioRunner.Node[]{
@@ -136,14 +145,16 @@ public class AsyncControllerTransactionTimingTest extends HTTP2TestBase {
                 node(fixture.http("S2", LATENCY))))
     };
     Result baseline = execute(ControllerKind.STOCK_TX_PARENT, 1, shape,
-        AsyncScenarioRunner.expiredScheduler());
+        AsyncScenarioRunner.stopAfter(LATENCY / 4));
     Result actual = execute(ControllerKind.ASYNC_PARENT, 1, shape,
-        AsyncScenarioRunner.expiredScheduler());
-    System.out.println("\n=== T4 scheduler already expired, transaction cut short ==="
+        AsyncScenarioRunner.stopAfter(LATENCY / 4));
+    System.out.println("\n=== T4 stopped from the outside, mid-flight ==="
         + "\n  stock: " + describeAll(baseline)
         + "\n  async: " + describeAll(actual));
 
     SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(baseline.hung()).as("the stock run must stop").isFalse();
+    softly.assertThat(actual.hung()).as("the async run must stop").isFalse();
     assertReportsDurationsNotEpochs(softly, "stock", baseline);
     assertReportsDurationsNotEpochs(softly, "async", actual);
     softly.assertAll();
@@ -166,6 +177,90 @@ public class AsyncControllerTransactionTimingTest extends HTTP2TestBase {
           .as("%s: '%s' was reported with %s ms", kind, sample.getSampleLabel(), sample.getTime())
           .isNotNegative();
     }
+  }
+
+  /**
+   * A scheduled end that falls while the requests are on the wire must not throw their responses
+   * away. A stock sampler never loses one: {@code stopSchedulerIfNeeded} runs after the sample
+   * returns, so a request that is already out always finishes and is reported, and its transaction
+   * closes with it inside. This controller keeps its requests out across turns, so without holding
+   * the deadline off the thread stopped between them - the responses were dropped and the
+   * transaction was reported empty, at 0 ms.
+   */
+  @Test
+  public void t5RequestsAlreadyOnTheWireMustSurviveTheScheduledEnd() {
+    TreeShape shape = fixture -> new AsyncScenarioRunner.Node[]{
+        node(fixture.controller("controller"),
+            node(fixture.http("S1", LATENCY)),
+            node(fixture.http("S2", LATENCY)))
+    };
+    // The end lands after the requests went out and well before they come back.
+    Result actual = execute(ControllerKind.ASYNC_PARENT, 1, shape,
+        AsyncScenarioRunner.schedulerEndingIn(LATENCY / 4));
+    SampleResult parent = actual.topLevelResult("controller");
+    report("T5 scheduled end falls mid-flight", actual, parent);
+
+    SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(actual.hung()).as("the thread must still stop, not outlive its schedule")
+        .isFalse();
+    softly.assertThat(parent).as("a parent sample must be reported").isNotNull();
+    if (parent != null) {
+      softly.assertThat(labelsOf(children(parent)))
+          .as("both responses were already on their way back, so both must be reported")
+          .containsExactly("S1", "S2");
+      softly.assertThat(parent.getTime())
+          .as("and the transaction must measure them, not come out as an empty 0 ms row")
+          .isGreaterThanOrEqualTo(LATENCY);
+    }
+    softly.assertAll();
+  }
+
+  /**
+   * Holding the scheduled end off is for the responses this controller already asked for, not a
+   * licence to keep asking: the children it had not dispatched yet when the end went by must stay
+   * undispatched, or a duration-limited run keeps putting load on the system under test after the
+   * time it was given, and the thread outlives its schedule by a whole controller block instead of
+   * by the responses that were on the wire.
+   */
+  @Test
+  public void t6NothingNewIsDispatchedOnceTheScheduledEndHasGoneBy() {
+    TreeShape shape = fixture -> new AsyncScenarioRunner.Node[]{
+        node(fixture.controller("controller"),
+            node(fixture.http("S1", LATENCY)),
+            node(fixture.http("S2", LATENCY)),
+            node(fixture.http("S3", LATENCY)),
+            node(fixture.http("S4", LATENCY)),
+            node(fixture.http("S5", LATENCY)))
+    };
+    // Over by the time the controller gets its second turn, whatever the machine's speed: dispatches
+    // cost microseconds, so a scheduled end a few milliseconds out is a race the test would lose.
+    Result actual = execute(ControllerKind.ASYNC_PARENT, 1, shape,
+        AsyncScenarioRunner.expiredScheduler());
+    SampleResult parent = actual.topLevelResult("controller");
+    report("T6 scheduled end falls after the first dispatches", actual, parent);
+    System.out.println("  dispatched: " + actual.dispatchOrder());
+
+    SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(actual.hung()).as("the thread must still stop").isFalse();
+    softly.assertThat(parent).as("a parent sample must be reported").isNotNull();
+    if (parent != null) {
+      softly.assertThat(labelsOf(children(parent)))
+          .as("the request that did go out must still be collected and reported")
+          .containsExactlyElementsOf(actual.dispatchOrder());
+      softly.assertThat(actual.dispatchOrder())
+          .as("the run was already over on the controller's second turn, so only the request that "
+              + "was on the wire by then may exist")
+          .containsExactly("S1");
+    }
+    softly.assertAll();
+  }
+
+  private static List<String> labelsOf(List<SampleResult> results) {
+    List<String> labels = new ArrayList<>();
+    for (SampleResult result : results) {
+      labels.add(result.getSampleLabel());
+    }
+    return labels;
   }
 
   /** Mirrors issue #155's test plan: parent sample on, think time excluded. */

--- a/src/test/java/com/blazemeter/jmeter/http2/control/async/AsyncScenarioRunner.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/control/async/AsyncScenarioRunner.java
@@ -167,9 +167,40 @@ public final class AsyncScenarioRunner {
    * child result at all yet.
    */
   public static Consumer<JMeterThread> expiredScheduler() {
+    return schedulerEndingIn(-1);
+  }
+
+  /**
+   * Thread Group scheduler whose end lands {@code millisFromNow} from the start of the run, so it
+   * can be made to fall while requests are still on the wire - which for this controller is most of
+   * the time, since its requests live across turns rather than inside one.
+   */
+  public static Consumer<JMeterThread> schedulerEndingIn(long millisFromNow) {
     return thread -> {
       thread.setScheduled(true);
-      thread.setEndTime(System.currentTimeMillis() - 1);
+      thread.setEndTime(System.currentTimeMillis() + millisFromNow);
+    };
+  }
+
+  /**
+   * Stops the thread from the outside {@code millisFromNow} into the run, the way the Stop button
+   * and {@code StandardJMeterEngine} do: straight onto the running flag, with no scheduled end
+   * involved. Nothing a controller does can hold that off, so whatever it had on the wire at that
+   * moment is lost - which is the situation the reported sample still has to survive.
+   */
+  public static Consumer<JMeterThread> stopAfter(long millisFromNow) {
+    return thread -> {
+      Thread stopper = new Thread(() -> {
+        try {
+          Thread.sleep(millisFromNow);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+        thread.stop();
+      }, "scenario-stopper");
+      stopper.setDaemon(true);
+      stopper.start();
     };
   }
 


### PR DESCRIPTION
This pull request introduces a new feature to the BlazeMeter HTTP Async Controller: it now ensures that when a thread group is configured to run for a fixed duration, any HTTP requests already dispatched by the controller are allowed to complete and be reported before the thread ends. This prevents losing in-flight results at the scheduled end of the run, improving result accuracy and consistency. The grace period for this behavior is configurable via a new property. The pull request also adds comprehensive documentation for this feature and for low-level logging and debugging options.

**Enhancements to request completion and scheduling:**

- Added support for holding off the thread's scheduled end while the controller has HTTP requests in flight, ensuring all dispatched requests are collected and reported before the thread stops. This is controlled by the new `blazemeter.http.schedulerHoldMillis` property, which can be tuned or disabled as needed. The property is documented in both the code and the `README.md`. [[1]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48R72-R76) [[2]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48R173-R288) [[3]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48R104) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R388-R398) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R416)
- Implemented logic to renew the scheduler hold both after each controller turn and during the completion polling loop, so the grace period is dynamically extended as long as requests are pending. [[1]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48R173-R288) [[2]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48R587-R589)

**Documentation improvements:**

- Expanded the `README.md` to explain the new request completion behavior, the `blazemeter.http.schedulerHoldMillis` property, and its effect on test runs with a scheduled duration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R388-R398) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R416)
- Added a new section on logging and low-level debugging, including how to enable detailed plugin and Jetty logs, and how to avoid excessive Jetty verbosity for clearer diagnostics. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R50-R51) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R446-R489)

**Code quality and maintainability:**

- Refactored transaction sample measurement to ensure accurate timing and robust handling when a run is cut short, preventing negative or zero-duration samples from skewing results. [[1]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48L186-R330) [[2]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48L223-R353)
- Replaced some `LOG.debug` calls with the plugin's internal `lowLevelDebug` method for more consistent and configurable low-level tracing. [[1]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48R3-R4) [[2]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48L451-R575) [[3]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48L512-R639)

These changes make the plugin more robust in scheduled runs, improve the accuracy of reported results, and provide better tools for diagnosing and debugging HTTP request execution.